### PR TITLE
[NO-MERGE] Mainline kevm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /node_modules/*
 /media/*.pdf
 /examples/*/behaviour.json
+/examples/*/out/*
+
+/package-lock.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "evm-semantics"]
 	path = evm-semantics
-	url = https://github.com/dapphub/evm-semantics
+	url = https://github.com/kframework/evm-semantics
 	ignore = untracked

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ default: deps
 
 clean:
 	rm -fdR out/* evm-semantics $(TMPDIR)/klab
-	git submodule update --init -- evm-semantics
+	git submodule sync
+	git submodule update --init --remote -- evm-semantics
 
 deps: deps-kevm deps-npm
 

--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ default: deps
 
 clean:
 	rm -fdR out/* evm-semantics $(TMPDIR)/klab
-	git submodule sync
-	git submodule update --init --remote -- evm-semantics
+	git submodule update --init -- evm-semantics
 
 deps: deps-kevm deps-npm
 
 deps-kevm:
-	git submodule update --init -- evm-semantics
+	git submodule sync
+	git submodule update --init --remote -- evm-semantics
 	cd evm-semantics \
 		&& make k-deps tangle-deps -B \
 		&& make build-java -B

--- a/README.md
+++ b/README.md
@@ -41,30 +41,21 @@ PREFIX=/path/to/custom/prefix make link
 
 ### Environment Setup
 
-You may wish to add the `klab` executable to the path, e.g.:
+The file `env` will setup the environment for you if sourced from the root directory of the repo.
 
 ```sh
-export PATH=$PATH:/path/to/klab/bin
+source env
 ```
 
-Prior to running `klab`, make sure the following environment variables are set:
+It sets three environment variables:
 
-```sh
-export KLAB_EVMS_PATH=/path/to/evm-semantics
-export TMPDIR=/tmp
-```
+-   `PATH`: include the `klab` executable.
+-   `KLAB_EVMS_PATH`: the EVM semantics to use.
+-   `TMPDIR`: temporary directory for KLab proof cacheing.
 
-The `evm-semantics` are located in this repo, e.g. if you cloned this repo to `/home/foo/repos/klab`, you should run:
+**OPTIONAL**: If you want to use a different version of K than what the KEVM ships with, you can set:
 
-```sh
-export KLAB_EVMS_PATH=/home/foo/repos/klab/evm-semantics
-```
-
-**OPTIONAL**: If you want to use a custom version of K you can also set:
-
-```sh
-export KLAB_K_PATH=/path/to/k
-```
+-   `KLAB_K_PATH`: override implementation of K.
 
 Running KLab
 ------------

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You may wish to add the `klab` executable to the path, e.g.:
 export PATH=$PATH:/path/to/klab/bin
 ```
 
-To run a `klab server`, you need to additionally set:
+Prior to running `klab`, make sure the following environment variables are set:
 
 ```sh
 export KLAB_EVMS_PATH=/path/to/evm-semantics

--- a/env
+++ b/env
@@ -1,0 +1,3 @@
+export PATH=$PATH:$(pwd)/bin
+export KLAB_EVMS_PATH=$(pwd)/evm-semantics
+export TMPDIR=/tmp

--- a/lib/pure.js
+++ b/lib/pure.js
@@ -51,9 +51,11 @@ const parse = {
 
 
 module.exports = msg => {
-  let data = msg.data.split(" ").slice(1);
-  return data[0] in parse
-    && Object.assign({type: data[0]}, parse[data[0]](data.slice(1)))
+  let data = msg.data.split(" ")
+  let [ time , type ] = data
+  let rest = data.slice(2)
+  return type in parse
+    && Object.assign({type: type}, {time: time}, parse[type](rest))
     || {type: "unknown", data}
 }
 

--- a/resources/run.sh
+++ b/resources/run.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/env bash
-K_OPTS=-Xmx10G $KLAB_EVMS_PATH/.build/k/k-distribution/target/release/k/bin/kprove --debugg --debugg-path $TMPDIR/klab --debugg-id $2 --directory $KLAB_EVMS_PATH/.build/java/ --z3-executable --def-module RULES --output-tokenize "#And _==K_ <k> #unsigned" --output-omit "<programBytes> <program> <code>" --output-flatten "_Map_ #And" --output json --smt_prelude ./prelude.smt2 --z3-tactic "(or-else (using-params smt :random-seed 3 :timeout 1000) (using-params smt :random-seed 2 :timeout 2000) (using-params smt :random-seed 1))" $1
+K_OPTS=-Xmx10G $KLAB_EVMS_PATH/.build/k/k-distribution/target/release/k/bin/kprove \
+    --debugg --debugg-path $TMPDIR/klab --debugg-id $2 \
+    --directory $KLAB_EVMS_PATH/.build/java/ --def-module RULES \
+    --z3-executable --smt_prelude ./prelude.smt2 --z3-tactic "(or-else (using-params smt :random-seed 3 :timeout 1000) (using-params smt :random-seed 2 :timeout 2000) (using-params smt :random-seed 1))" $1 \
+    --output json \
+    --output-tokenize "#And _==K_ <k> #unsigned" \
+    --output-omit "<programBytes> <program> <code>" \
+    --output-flatten "_Map_ #And"


### PR DESCRIPTION
@mhhf, @MrChico, and @livnev, this PR tests https://github.com/kframework/k/pull/175.

I don't think the CI on this repo is testing any of the UX, and I'm pretty sure some of the views that were there before are broken now. I've converted the message log parser to the new format (which includes some timing information as well), so at least the clients receives the correct blobs now.

I'd like to get the Debugg PR merged into K, then you guys can decide whether you want to switch the submodule to kframework/evm-semantics, or just do the sequence of merges into your forks of the repos.