### PR TITLE
Makefile: don't set TMPDIR, can cause build issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,7 @@
 PATH:=$(PATH):$(CURDIR)/bin
 KLAB_EVMS_PATH:=$(CURDIR)/evm-semantics
-TMPDIR=$(CURDIR)/tmp
 export PATH
 export KLAB_EVMS_PATH
-export TMPDIR
 
 # shell output colouring:
 red:=$(shell tput setaf 1)


### PR DESCRIPTION
Minor fix, this environment variable was causing `make deps` to fail on one machine.