### PR TITLE
[WIP] Refactor klab memes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,3 @@
-An easiest way to install is through docker.
-```sh
-docker run -it dapphub/klab
-```
-
 KLab
 ====
 **NOTE:** This software is still in the early stages of development. If you are confused, find some bugs, or just want some help, please file an issue or come talk to us at <https://dapphub.chat/channel/k-framework>.
@@ -17,6 +12,14 @@ Ask at <https://dapphub.chat/channel/k-framework> for access to a KLab server if
 
 Setting up KLab Server and Client
 ---------------------------------
+
+One option is to use Docker:
+
+```sh
+docker run -it dapphub/klab
+```
+
+[See below](#docker) for details on using Docker.
 
 ### Dependencies
 Installing klab automatically installs `K` and `KEVM`. You will therefore need the dependencies of K.

--- a/README.md
+++ b/README.md
@@ -114,10 +114,10 @@ klab build
 This will generate a fail and success reachability rule for each `act` of your specification in the `SafeAdd/out/specs` directory.
 
 ### Running proofs
-To explore a proof with the interactive klab GUI, use `klab run`, specifying which proof to explore using the `--spec` flag:
+To explore a proof with the interactive klab GUI, use `klab debug`, specifying which proof to explore using the `--spec` flag:
 
 ```sh
-klab run --spec out/specs/proof-SafeAdd_add_succ.k
+klab debug --spec out/specs/proof-SafeAdd_add_succ.k
 ```
 
 To ensure that a cached version of the proof is not being used, run `klab` with the `--force` option.
@@ -225,7 +225,7 @@ klab server
 # Start client
 docker exec -it klab bash
 cd /docker/SafeAdd
-klab run
+klab debug
 ```
 
 # License

--- a/examples/SafeAdd/src/prelude.smt2.md
+++ b/examples/SafeAdd/src/prelude.smt2.md
@@ -1,4 +1,4 @@
-```
+```smt2
 (set-option :auto-config false)
 (set-option :smt.mbqi false)
 ;(set-option :smt.mbqi.max_iterations 15)

--- a/examples/SafeAdd/src/specification.act.md
+++ b/examples/SafeAdd/src/specification.act.md
@@ -1,5 +1,5 @@
 
-```
+```act
 behaviour add of SafeAdd
 interface add(uint256 X, uint256 Y)
 

--- a/examples/d0_suck/src/lemmas.k.md
+++ b/examples/d0_suck/src/lemmas.k.md
@@ -1,4 +1,4 @@
-```
+```k
 rule #take(N, #padToWidth(N, X) ++ Z ) => X
 rule #asWord( #asByteStack( X ) ) => X
 

--- a/examples/d0_suck/src/prelude.smt2.md
+++ b/examples/d0_suck/src/prelude.smt2.md
@@ -1,5 +1,5 @@
 
-```
+```smt2
 (set-option :auto-config false)
 (set-option :smt.mbqi false)
 ;(set-option :smt.mbqi.max_iterations 15)

--- a/examples/d0_suck/src/specification.act.md
+++ b/examples/d0_suck/src/specification.act.md
@@ -1,5 +1,5 @@
 
-```
+```act
 behaviour suck of D0Impl
 interface suck(address u, int256 Delta_D)
 

--- a/examples/multipleCalls/src/lemmas.k.md
+++ b/examples/multipleCalls/src/lemmas.k.md
@@ -1,5 +1,5 @@
 
-```
+```k
 rule #padToWidth(32, #asByteStack(#unsigned(V))) => #asByteStackInWidth(#unsigned(V), 32)
     requires #rangeSInt(256, V)
 

--- a/examples/multipleCalls/src/prelude.smt2.md
+++ b/examples/multipleCalls/src/prelude.smt2.md
@@ -1,4 +1,4 @@
-```
+```smt2
 (set-option :auto-config false)
 (set-option :smt.mbqi false)
 ;(set-option :smt.mbqi.max_iterations 15)

--- a/examples/multipleCalls/src/specification.act.md
+++ b/examples/multipleCalls/src/specification.act.md
@@ -1,5 +1,5 @@
 
-```
+```act
 behaviour calling of easyNest
 interface raiseTemp(uint256 x)
 

--- a/examples/token/src/prelude.smt2.md
+++ b/examples/token/src/prelude.smt2.md
@@ -1,4 +1,4 @@
-```
+```smt2
 (set-option :auto-config false)
 (set-option :smt.mbqi false)
 ;(set-option :smt.mbqi.max_iterations 15)

--- a/examples/token/src/spec.md
+++ b/examples/token/src/spec.md
@@ -1,4 +1,4 @@
-```
+```act
 behaviour transfer of Token
 interface transfer(address To, uint Value)
 

--- a/libexec/klab-debug
+++ b/libexec/klab-debug
@@ -6,7 +6,7 @@ const fs = require("fs");
 const path = require("path");
 const makeConfig = require("../lib/config.js");
 process.title = "klab";
-// TODO - klab run should send the config.json to the server
+// TODO - klab debug should send the config.json to the server
 
 const makeCliDriver = require("../lib/driver/cliDriver.js")
 const remoteDriver = require("../lib/driver/remoteDriver.js")
@@ -20,7 +20,7 @@ const {
 
 const usage = `
 Usage:
-  klab run [options]
+  klab debug [options]
 
 Options:
   --force               No replay
@@ -35,7 +35,7 @@ Options:
 const KLAB_OUT = process.env.KLAB_OUT || "out";
 
 const cmd = docopt(usage, {
-  argv: ["run"].concat(process.argv.slice(2))
+  argv: ["debug"].concat(process.argv.slice(2))
 });
 
 const config_json = JSON.parse(fs.readFileSync("./config.json"));
@@ -54,7 +54,7 @@ config.spec = cmd["--spec"] && (
     || revert(`spec not found at ${cmd["--spec"]}`))
   || cmd["--name"] && (cmd["--name"] in spec_names)
     && read(path.join(KLAB_OUT, `specs/proof-${cmd["name"]}.k`))
-  || revert("no --spec or --name provided. Try `klab run --spec out/specs/SOME_SPEC`");
+  || revert("no --spec or --name provided. Try `klab debug --spec out/specs/SOME_SPEC`");
 
 config.name = cmd["--spec"] && path.basename(cmd["--spec"])
   || cmd["--name"] && ("proof-" + name + ".k")

--- a/libexec/klab-prove
+++ b/libexec/klab-prove
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -e
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+yellow=$(tput setaf 3)
+bold=$(tput bold)
+reset=$(tput sgr0)
+
+if [ -z "$KLAB_OUT" ]; then
+    echo "KLAB_OUT not set, defaulting to ./out/"
+    export KLAB_OUT=out
+fi
+
+if [ -z "$KLAB_EVMS_PATH" ]; then
+    echo "KLAB_EVMS_PATH must be set and point to evm-semantics!"
+    exit 1
+fi
+
+if [ -z "$TMPDIR" ]; then
+    echo "TMPDIR must be set!"
+    exit 1
+fi
+
+DUMP_FLAGS="--debugg --debugg-path $TMPDIR/klab --debugg-id"
+
+if [[ $1 == --dump ]]; then
+    TARGET_SPEC=$2
+    EXTRA_FLAGS="$DUMP_FLAGS $(klab hash --spec $TARGET_SPEC)"    
+    DUMP_NOTICE="(with ${yellow}state dumping${reset})"
+else
+    EXTRA_FLAGS=""
+    TARGET_SPEC=$1
+fi
+
+echo "Proof ${bold}STARTING${reset}:" "$(basename $TARGET_SPEC)" $DUMP_NOTICE
+
+result=$(K_OPTS=-Xmx10G $KLAB_EVMS_PATH/.build/k/k-distribution/target/release/k/bin/kprove $EXTRA_FLAGS --directory $KLAB_EVMS_PATH/.build/java/ --z3-executable --def-module RULES --output-tokenize "#And _==K_ <k> #unsigned" --output-omit "<programBytes> <program> <code>" --output-flatten "_Map_ #And" --output json --smt_prelude $KLAB_OUT/prelude.smt2 --z3-tactic "(or-else (using-params smt :random-seed 3 :timeout 1000) (using-params smt :random-seed 2 :timeout 2000) (using-params smt :random-seed 1))" $TARGET_SPEC)
+
+if [[ result -ne 0 ]]; then
+    echo "${red}Proof ${bold}REJECT${reset}:" $(basename $TARGET_SPEC) $DUMP_NOTICE
+else
+    echo "${green}Proof ${bold}ACCEPT${reset}:" $(basename $TARGET_SPEC) $DUMP_NOTICE
+fi


### PR DESCRIPTION
The main change is to rename `klab run` to `klab debug`, and to add a command `klab prove [--dump]` which is a simple wrapper around `kprove` (similar to `run.sh`).

**TODO**: add `--help` / `usage` output. [Don't merge]

This PR also tidies the docker instructions in the readme, and adds `act` and `k` tags to all markdown code blocks in the examples, for better editor integration.

n.b. that this is backwards incompatible because `klab run` is removed, so CI will need to be changed in order to test this properly. If you prefer we can make `klab run` an alias for backwards compatibility (though my vote is against).