### PR TITLE
 multipleCalls/Makefile: uses new batched proof scheme 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ build-test-exactgas : $(test_examples:=.build-exactgas)
 	cd $* && $(KLAB) build
 
 %.build-exactgas:
-	cd $* && $(KLAB) solve-gas && $(KLAB) build --exact-gas
+	cd $* && $(KLAB) solve-gas && $(KLAB) build
 
 # workaround for patsubst in pattern matching target below
 PERCENT := %

--- a/examples/multipleCalls/Makefile
+++ b/examples/multipleCalls/Makefile
@@ -19,6 +19,14 @@ BATCH_TIMESTAMP = $(KLAB_OUT)/batch.timestamp
 SPEC_DIR = $(KLAB_OUT)/specs
 GAS_DIR = $(KLAB_OUT)/gas
 
+# read obligations file if it exists
+ifneq ("$(wildcard $(OBLIGATIONS))","")
+obligation_spec_names = $(shell cat ${OBLIGATIONS})
+obligation_specs = $(addsuffix .k,$(addprefix $(SPEC_DIR)/,$(obligation_spec_names)))
+num_obligations = $(shell cat $(OBLIGATIONS) | wc -l)
+endif
+
+
 all: $(OBLIGATIONS)
 	mkdir -p $(GAS_DIR)
 	@ count=1; \
@@ -40,13 +48,6 @@ $(OBLIGATIONS): $(BATCH_TIMESTAMP)
 
 clean:
 	rm -rf $(KLAB_OUT)/*
-
-# read obligations file if it exists
-ifneq ("$(wildcard $(OBLIGATIONS))","")
-obligation_spec_names != cat $(OBLIGATIONS)
-obligation_specs = $(addsuffix .k,$(addprefix $(SPEC_DIR)/,$(obligation_spec_names)))
-num_obligations = $(shell cat $(OBLIGATIONS) | wc -l)
-endif
 
 .SECONDEXPANSION:
 

--- a/examples/multipleCalls/Makefile
+++ b/examples/multipleCalls/Makefile
@@ -31,7 +31,7 @@ all: $(OBLIGATIONS)
 		$(MAKE) -C ./ proof-batch || exit 1 ; \
 		count=$$((count+1)); \
 	done; \
-        echo $(bold)COMPLETE$(reset): no outstanding proof obligations.
+        echo "$(bold)COMPLETE$(reset): no outstanding proof obligations."
 
 $(BATCH_TIMESTAMP):
 

--- a/examples/multipleCalls/Makefile
+++ b/examples/multipleCalls/Makefile
@@ -44,7 +44,7 @@ all: $(OBLIGATIONS)
 $(BATCH_TIMESTAMP):
 
 $(OBLIGATIONS): $(BATCH_TIMESTAMP)
-	klab build --exact-gas
+	klab build
 
 clean:
 	rm -rf $(KLAB_OUT)/*
@@ -54,7 +54,7 @@ clean:
 proof-batch: $$(addsuffix .proof.timestamp,$$(obligation_specs))
 	$(info $(bold)FINISHED$(reset) batch.)
 	touch $(BATCH_TIMESTAMP)
-	klab build --exact-gas
+	klab build
 
 %.k.proof.timestamp: %.k $(OBLIGATIONS)
 	klab prove --dump $<

--- a/examples/multipleCalls/Makefile
+++ b/examples/multipleCalls/Makefile
@@ -1,0 +1,62 @@
+# increase this if you need to do more batches
+BATCH_LIMIT ?= 5
+
+SHELL ?= /usr/bin/env bash
+
+# shell output colouring:
+red:=$(shell tput setaf 1)
+green:=$(shell tput setaf 2)
+yellow:=$(shell tput setaf 3)
+bold:=$(shell tput bold)
+reset:=$(shell tput sgr0)
+
+KLAB_OUT ?= $(CURDIR)/out
+TMPDIR ?= $(CURDIR)/tmp
+export KLAB_OUT
+export TMPDIR
+OBLIGATIONS = $(KLAB_OUT)/obligations.batch
+BATCH_TIMESTAMP = $(KLAB_OUT)/batch.timestamp
+SPEC_DIR = $(KLAB_OUT)/specs
+GAS_DIR = $(KLAB_OUT)/gas
+
+all: $(OBLIGATIONS)
+	mkdir -p $(GAS_DIR)
+	@ count=1; \
+	while [ -s  $(OBLIGATIONS) ]; do \
+		if [ $$count -gt $(BATCH_LIMIT) ]; then \
+			echo "$(red)Exceeded batch limit, terminating!"; \
+			exit 1 ; \
+		fi ; \
+		echo "$(bold)STARTING$(reset) proof batch $$count." ; \
+		$(MAKE) -C ./ proof-batch || exit 1 ; \
+		count=$$((count+1)); \
+	done; \
+        echo $(bold)COMPLETE$(reset): no outstanding proof obligations.
+
+$(BATCH_TIMESTAMP):
+
+$(OBLIGATIONS): $(BATCH_TIMESTAMP)
+	klab build --exact-gas
+
+clean:
+	rm -rf $(KLAB_OUT)/*
+
+# read obligations file if it exists
+ifneq ("$(wildcard $(OBLIGATIONS))","")
+obligation_spec_names != cat $(OBLIGATIONS)
+obligation_specs = $(addsuffix .k,$(addprefix $(SPEC_DIR)/,$(obligation_spec_names)))
+num_obligations = $(shell cat $(OBLIGATIONS) | wc -l)
+endif
+
+.SECONDEXPANSION:
+
+proof-batch: $$(addsuffix .proof.timestamp,$$(obligation_specs))
+	$(info $(bold)FINISHED$(reset) batch.)
+	touch $(BATCH_TIMESTAMP)
+	klab build --exact-gas
+
+%.k.proof.timestamp: %.k $(OBLIGATIONS)
+	klab prove --dump $<
+	klab get-gas $< > $(GAS_DIR)/$(*F).raw.kast.json
+	klab gas-analyser --input $(GAS_DIR)/$(*F).raw.kast.json > $(GAS_DIR)/$(*F).kast
+

--- a/lib/kast.js
+++ b/lib/kast.js
@@ -241,7 +241,12 @@ const format = (o, isRaw = false) => {
     if((!isRaw) && o.label in infix) {
       o = "( " + childs.join(infix[o.label]) + " )"
     } else {
-      o = `\`${o.label}\` ( ${childs.reduce((a, b) => a !== "" ? `${a}, ${b}` : b, "")} )`
+      let cr = childs.reverse();
+      let clean_label = o.label.split("_").length > cr.length + 1
+        ? o.label.split("_").slice(0, -1).join("_")
+        : o.label
+      o = "(" + clean_label.replace(/_/g, () => ` ${cr.pop()} `) + ")"
+      // o = `\`${o.label}\` ( ${childs.reduce((a, b) => a !== "" ? `${a}, ${b}` : b, "")} )`
     }
   } else {
     return `UNKNOWN<${ JSON.stringify(o) }>`

--- a/libexec/klab-build
+++ b/libexec/klab-build
@@ -35,7 +35,7 @@ Usage:
 Options:
   --filter=<filter>
   --trust
-  --exact-gas
+  --debug
 `
 const cmd = docopt(usage, {
   argv: ["build"].concat(process.argv.slice(2))
@@ -46,7 +46,7 @@ const config_json   = JSON.parse(fs.readFileSync("./config.json"));
 const config        = makeConfig(config_json);
 const config_path   = cmd["<spec>"] || config.src.specification;
 const filter_subject= cmd["--filter"] || null;
-const EXACT_GAS     = cmd["--exact-gas"] || false;
+const DEBUG         = cmd["--debug"] || false;
 config.trusted      = cmd["--trust"];
 
 const raw_md_config = read(config_path)
@@ -108,9 +108,9 @@ const proof_collection = act_collection
   // enrich with gas statements
   .map(pf => {
     // TODO - default
-    pf.act.hasGas = EXACT_GAS && __hasGas(pf.name) && pf.pass;
+    pf.act.hasGas = __hasGas(pf.name) && pf.pass;
     var gas = "3000000";
-    if(EXACT_GAS && __hasGas(pf.name) && pf.pass) {
+    if(__hasGas(pf.name) && pf.pass) {
       pf.act.gas = __getGas(pf.name);
       pf.act.gas_raw = kast.format(__getGasRaw(pf.name), true);
       return [{...pf, oog: false, name: pf.name.replace('_rough','')},
@@ -152,7 +152,7 @@ const grounded_proofs = act_proofs
 grounded_proofs
   .forEach(rule => {
       if (rule.ctx.length > 0) {console.log("Importing " + rule.ctx.map(r => r.name) + " as lemma(s) to " + rule.name)}
-    const _rules = [rule.spec].concat(rule.ctx.map(r => r.spec))
+    const _rules = [rule.spec].concat(rule.ctx.map(r => r.spec  + "\n[trusted]\n"))
     const module = kjson.renderModule(_rules, rule.name)
     const hash   = get_proof_hash(module);
     rule.module  = module;


### PR DESCRIPTION
A new `Makefile` compatible with batched proofs. 

To test this out:
```sh
cd examples/multipleCalls
make -j2
```

If this one looks good we can use the same `Makefile` for all of the examples, there's nothing in it that's specific to `multipleCalls`. Each example can have a `Makefile` consisting of `import ../../resources/example.Makefile`.