### PR TITLE
Update git repository path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ brew install automake libtool gmp mpfr pkg-config pandoc maven opam z3 node
 ### Installing
 Clone the repo and install with
 ```sh
-git clone git@github.com:dapphub/klab.git
+git clone https://github.com/dapphub/klab.git
 cd klab
 make deps
 ```


### PR DESCRIPTION
The path for `git clone` in the `README.md` works only for users in the dapphub organisation. 
Updated to work for all users.