### PR TITLE
examples/multipleCalls: generalise the spec

### DIFF
--- a/examples/SafeAdd/Makefile
+++ b/examples/SafeAdd/Makefile
@@ -65,6 +65,9 @@ proof-batch: $$(addsuffix .proof.timestamp,$$(obligation_specs))
 	touch $(BATCH_TIMESTAMP)
 	klab build
 
+%_fail.k.proof.timestamp: %_fail.k $(OBLIGATIONS)
+	klab prove --dump $<
+
 %.k.proof.timestamp: %.k $(OBLIGATIONS)
 	klab prove --dump $<
 	klab get-gas $< > $(GAS_DIR)/$(*F).raw.kast.json

--- a/examples/d0_suck/Makefile
+++ b/examples/d0_suck/Makefile
@@ -65,6 +65,9 @@ proof-batch: $$(addsuffix .proof.timestamp,$$(obligation_specs))
 	touch $(BATCH_TIMESTAMP)
 	klab build
 
+%_fail.k.proof.timestamp: %_fail.k $(OBLIGATIONS)
+	klab prove --dump $<
+
 %.k.proof.timestamp: %.k $(OBLIGATIONS)
 	klab prove --dump $<
 	klab get-gas $< > $(GAS_DIR)/$(*F).raw.kast.json

--- a/examples/multipleCalls/Makefile
+++ b/examples/multipleCalls/Makefile
@@ -65,6 +65,9 @@ proof-batch: $$(addsuffix .proof.timestamp,$$(obligation_specs))
 	touch $(BATCH_TIMESTAMP)
 	klab build
 
+%_fail.k.proof.timestamp: %_fail.k $(OBLIGATIONS)
+	klab prove --dump $<
+
 %.k.proof.timestamp: %.k $(OBLIGATIONS)
 	klab prove --dump $<
 	klab get-gas $< > $(GAS_DIR)/$(*F).raw.kast.json

--- a/examples/multipleCalls/src/specification.act.md
+++ b/examples/multipleCalls/src/specification.act.md
@@ -1,11 +1,11 @@
-
 ```act
 behaviour calling of easyNest
 interface raiseTemp(uint256 x)
 
 types
 
-  CALLEE : address Callee
+  CALLEE      : address Callee
+  Temperature : uint256
 
 storage
 
@@ -13,38 +13,57 @@ storage
 
 storage CALLEE
 
-  0 |-> 0 => x
+  0 |-> Temperature => Temperature + x
+
+iff in range uint256
+
+  Temperature + x
 
 iff
+
   VCallDepth < 1024
 
 calls
 
   Callee.tempDelta
+```
 
+```act
 behaviour tempDelta of Callee
 interface tempDelta(uint256 x)
 
+types
+
+  Temperature : uint256
+
 storage
 
-  0 |-> 0 => x
-   
+  0 |-> Temperature => Temperature + x
+
+iff in range uint256
+
+  Temperature + x
+
 calls
+
    Callee.add
 ```
+
 We can extract the pc values of internal solidity functions:
-```
+
+```act
 behaviour add of Callee
 interface add(uint256 x, uint256 y) internal
 
 stack
+
    x : y : JUMPTo : WS => JUMPTo : x + y : WS
 
 iff in range uint256
+
     x + y
 
-if 
-   #sizeWordStack (WS) <= 1018
-   
-```
+if
 
+   #sizeWordStack (WS) <= 1018   
+```

--- a/examples/token/Makefile
+++ b/examples/token/Makefile
@@ -65,6 +65,9 @@ proof-batch: $$(addsuffix .proof.timestamp,$$(obligation_specs))
 	touch $(BATCH_TIMESTAMP)
 	klab build
 
+%_fail.k.proof.timestamp: %_fail.k $(OBLIGATIONS)
+	klab prove --dump $<
+
 %.k.proof.timestamp: %.k $(OBLIGATIONS)
 	klab prove --dump $<
 	klab get-gas $< > $(GAS_DIR)/$(*F).raw.kast.json


### PR DESCRIPTION
I noticed that this spec was not general enough, in that the initial value of slot `0` in `Callee` was assumed to be `0`. I think there is value to this example having branching, which otherwise it doesn't have, since it would then be a better test of spec-lemma application, gas behaviour display, etc., so I'm proposing to make this spec fully general by abstracting `Temperature`.

Also, this is a useful test case to keep in mind when thinking about what can make specs non-exhaustive: we must remember that the way that you phrase the precondition can have certain unjustified assumptions...