### PR TITLE
fix docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ RUN apt-get -y install nodejs
 
 # build source
 WORKDIR klab
-RUN git clone https://github.com/dapphub/klab
-RUN cd klab
+RUN git clone https://github.com/dapphub/klab /klab
 RUN make deps
 
 # env setup


### PR DESCRIPTION
### Fixes docker build

Building docker image was failing at `make deps` command. This PR fixes it.

Error log
```shell
Step 13/16 : RUN make deps
 ---> Running in 7b8ab7d4cb60
make: *** No rule to make target 'deps'.  Stop.
```

##### How to test this dockerfile 
```
docker build .
```