### PR TITLE
Calldata

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -190,10 +190,10 @@ const parseAct = config => (act_str, silent = false) => {
           ...a.types,
           ..._interface_types
         }
-        a.if = [
-                ...(a.if || []),
+        a.if = a.internal ? a.if :
+          (a.if || []).concat(
                 `#sizeWordStack(CD) <=Int 1250000000` //10^4 times the current block gas limit of 8M
-              ]
+          )
         a.interface = interface;
         a.fname = fname;
       } else if ((/^types/.test(head))||(/^for all/.test(head))) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -166,7 +166,7 @@ const parseAct = config => (act_str, silent = false) => {
         let interface_str = head
           .split(" ")
           .slice(1)
-          .join(" ");
+          .join(" ")
         a.internal = interface_str.split(' ').slice(-1) == 'internal' ? true : false;
         interface_str = interface_str.replace(' internal','')
         const interface  = interface_str
@@ -181,7 +181,8 @@ const parseAct = config => (act_str, silent = false) => {
             a["ABI_" + k] = longForm(v);
             return a;
           }, {})
-        const fname = interface_str.slice(0, interface_str.indexOf("("))
+        let fname = interface_str.slice(0, interface_str.indexOf("("))
+        a.sig =  fname + "(" + (Object.values(_interface_types)).toString() + ")"
         a.callData = `#abiCallData("${fname}", ${make_args(interface.map(([type, name]) => ({type, name})))}) ++ CD`
         a.signature = fname + "(" + interface
           .map(([t, v]) => t).join(",") + ")"
@@ -471,8 +472,8 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, gas_raw}) => {
     .map(name => `SetItem(${name})`)
     .join("\n").concat(" _")
 
-    if (act.internal) {
-     let pc_range = srchandler.functionNameToPcRange(act.name,
+  if (act.internal) {
+     let pc_range = srchandler.functionNameToPcRange(act.sig,
                                                         config.contracts[act.subject].srcmapArr,
                                                         config.contracts[act.subject].ast,
                                                         config.contracts[act.subject].bin_runtime,

--- a/lib/build.js
+++ b/lib/build.js
@@ -362,7 +362,7 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, gas_raw}) => {
       "k": "#execute ~> CONTINUATION => " + ((act.internal && pass && !(oog)) ? "#execute ~> CONTINUATION" : "#halt ~> CONTINUATION"),
     "ethereum.evm.callState.programBytes": `#parseByteStack("0x${config.contracts[act.subject].bin_runtime}")`,
     "ethereum.evm.callState.program":  `#asMapOpCodes(#dasmOpCodes(#parseByteStack("0x${config.contracts[act.subject].bin_runtime}"), PETERSBURG))`,
-    "ethereum.evm.callState.callData": act.callData,
+    "ethereum.evm.callState.callData": act.callData + ` => _`,
     "ethereum.evm.callState.wordStack": wordstack,
     "ethereum.evm.callState.localMem": act.internal ? "_" : ".Map => _",
     "ethereum.evm.callState.pc": pc,

--- a/lib/constraints.js
+++ b/lib/constraints.js
@@ -33,6 +33,7 @@ const deltaC = (state, step) => {
 }
 
 const deltaCC = (c1_, c2_) => {
+  if (c1_.format && c1_.format == 'KAST') {c1_ = c1_.term; c2_ = c2_.term;}
   let c1 = c1_.args
       .map(s => kast.format(s))
   let c2 = c2_

--- a/lib/kast.js
+++ b/lib/kast.js
@@ -227,14 +227,26 @@ const format = (o, isRaw = false, mixFix = false) => {
       : o.originalName
       ;
   } else if(o.node == KTOKEN) {
-      let tokenMap = {
-        ".IntList": "",
-        ".List{\"intList\"}": "",
-        ".WordStack_EVM-DATA": "",
-      }
-      o = o.token in tokenMap ? tokenMap[o.token] : o.token;
-  } else if(o.node == KAPPLY) {
-    let childs = o.args.map(child => format(child, isRaw, mixFix));
+    o = o.token
+  }   
+  else if(o.node == KAPPLY) {
+    let associative = {
+      "intList": true
+    }
+    let assoc = o.label in associative;
+    let tokenMap = {
+      "keccakIntList": "keccak",
+      ".IntList": "",
+      "intList" : "",
+      ".List{\"intList\"}": "",
+      ".WordStack_EVM-DATA": "",
+    }
+    o.label = o.label in tokenMap ? tokenMap[o.label] : o.label;
+    const childs = o.args.map(child => format(child, isRaw, mixFix))
+        .filter(s => !(s == ''));
+    if (childs.length == 0) {
+      return o.label;
+    }
     let infix = {
       "_-Int__INT": " - ",
       "_+Int__INT": " + ",
@@ -256,7 +268,7 @@ const format = (o, isRaw = false, mixFix = false) => {
       "_|->_": ' |-> '
     }
     if((!isRaw) && o.label in infix) {
-      o = "( " + childs.join(infix[o.label]) + " )"
+      o = childs.join(infix[o.label])
     } else if (o.label[0] == "<" && o.label[o.label.length - 1] == ">") {
       let indentedChildren = childs.map(gChild => gChild.split("\n").join("\n  "))
       o = o.label + "\n  " + indentedChildren.join("\n  ") + "\n</" + o.label.slice(1)
@@ -265,10 +277,12 @@ const format = (o, isRaw = false, mixFix = false) => {
       let clean_label = o.label.split("_").length > cr.length + 1
         ? o.label.split("_").slice(0, -1).join("_")
         : o.label
-      o = "(" + clean_label.replace(/_/g, () => ` ${cr.pop()} `) + ")"
+      o = clean_label.replace(/_/g, () => ` ${cr.pop()} `)
       // o = `\`${o.label}\` ( ${childs.reduce((a, b) => a !== "" ? `${a}, ${b}` : b, "")} )`
     } else {
-      o = "`" +  o.label + "`(" + childs.join(" , ") + ")";
+      o = o.label + (assoc ? childs.join(", ") : "(" + childs.join(", ") + ")")
+    // } else {
+    //   o = o.label;
     }
   } else {
     return `UNKNOWN<${ JSON.stringify(o) }>`

--- a/lib/srchandler.js
+++ b/lib/srchandler.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const clc = require('cli-color');
 const tw = process.stdout.columns; // total width
+const deepEqual = require('deep-equal');
 
 // EVM Instructions
 const evm_i = require("./evm.json");
@@ -150,16 +151,18 @@ const getCodeStringFromPc = (srcs, contract, pc, trim) => {
   return str;
 }
 
-let getNodeSrcAst = (ast, name) => {
+let getNodeSrcAst = (ast, name, args) => {
     return ast.map(node => {
-        if (node.attributes && node.attributes.name) {
-            if (node.attributes.name == name) {
-                return node.src;
-            }
+      if (node.attributes && node.attributes.name && node.attributes.name == name) {
+        let fArgTypes = node.children[0].children.map(s => s.attributes.type)
+        if (deepEqual(fArgTypes,args))
+        {
+          return node.src;
         }
-        if (node.children) {
-            return getNodeSrcAst(node.children, name).join('');
-        }
+      }
+      if (node.children) {
+        return getNodeSrcAst(node.children, name, args).join('');
+      }
     })
 }
 
@@ -177,9 +180,14 @@ let getContractAst = (ast, contractName) => {
 
 }
 
-let functionNameToPcRange = (name, srcmapArr, ast, bin_runtime, inst_to_pc) => {
+let functionNameToPcRange = (sig, srcmapArr, ast, bin_runtime, inst_to_pc) => {
+    let name = sig.split('(')[0]
+    let args = sig.split('(')
+      .slice(1).join('')
+      .replace(')','')
+        .split(',')
     let pcList = get_pc_to_inst_map(bin_runtime).pc_to_inst_map;
-    let srcFromAst = getNodeSrcAst([ast], name)[0];
+    let srcFromAst = getNodeSrcAst([ast], name, args)[0];
     let s_l_f = srcmapArr.map(e => [e.s, e.l, e.f].join(':'));
     let start_index = s_l_f.indexOf(srcFromAst)
     //Find the corresponding jump 'out'

--- a/libexec/klab-hash
+++ b/libexec/klab-hash
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
-
+const fs            = require("fs");
 const {docopt}      = require("docopt");
 const path          = require('path');
 const {
   testPath,
-  read
+  read,
+  warn
 } = require("../lib/util.js");
 
 const KLAB_OUT     = process.env.KLAB_OUT || "out";
@@ -23,6 +24,8 @@ const name = path.basename(spec, '.k');
 
 const hash_path = path.join(KLAB_OUT, 'meta', 'name', name);
 
-if(!testPath(hash_path)) process.exit(1);
-
+if(!testPath(hash_path)) {
+  fs.writeFileSync(hash_path, name);
+  warn(`No hash found, writing debug output under ${name}`);
+}
 process.stdout.write(read(hash_path))


### PR DESCRIPTION
- Loosens the restriction on calldata to `<callData> CD => _ </callData>` instead of `<callData> CD </callData>`
- `pc` extraction supports overloaded function names