### PR TITLE
show order of operations in pretty printing

### DIFF
--- a/lib/kast.js
+++ b/lib/kast.js
@@ -266,6 +266,9 @@ const format = (o, isRaw = false, mixFix = false) => {
       "_<=Int__INT-COMMON" : " <= "  ,
       "_>Int__INT-COMMON"  : " > "   ,
       "_>=Int__INT-COMMON" : " >= "  ,
+      "_|Int__INT-COMMON"  : " | "   ,
+      "_&Int__INT-COMMON"  : " & "   ,
+
 
       "_+Word__EVM-DATA"   : " +W "  ,
       "_-Word__EVM-DATA"   : " -W "  ,
@@ -273,6 +276,8 @@ const format = (o, isRaw = false, mixFix = false) => {
       "_/Word__EVM-DATA"   : " /W "  ,
       "_%Word__EVM-DATA"   : " %W "  ,
       "_^Word__EVM-DATA"   : " ^W "  ,
+
+      "_+Map__RULES"       : " +M "  ,
 
       "_andBool_"          : " AND " ,
       "_:__EVM-DATA"       : " : "   ,
@@ -283,7 +288,7 @@ const format = (o, isRaw = false, mixFix = false) => {
       "_|->_"              : " |-> "
     }
     if((!isRaw) && o.label in infix) {
-      o = childs.join(infix[o.label])
+      o = "(" + childs.join(infix[o.label]) + ")"
     } else if (o.label[0] == "<" && o.label[o.label.length - 1] == ">") {
       let indentedChildren = childs.map(gChild => gChild.split("\n").join("\n  "))
       o = o.label + "\n  " + indentedChildren.join("\n  ") + "\n</" + o.label.slice(1)


### PR DESCRIPTION
The current infix notation can be ambiguous when multiple operations are composed. Enclosing every operation in a set of parens fixes this, although we could try to be smarter about when it's necessary.