### PR TITLE
Use builtin symbolic-map rather than +Map hack

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -380,10 +380,12 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, gas_raw}) => {
   })
     const buildAccount = varname => {
         let storage_pass = Object.keys(act.storage[varname])
-            .reduce((a, key) => `((${a}) +Map (${storagekeys(realname(varname), key)} |-> (${clean(act.storage[varname][key][0])} => ${clean(act.storage[varname][key][1])})))`, `.Map`)
+            .map(key => `[${storagekeys(realname(varname), key)} <- (${clean(act.storage[varname][key][0])} => ${clean(act.storage[varname][key][1])})]`)
+            .join('        \n');
         let storage_fail = Object.keys(act.storage[varname])
-            .reduce((a, key) => `((${a}) +Map (${storagekeys(realname(varname), key)} |-> (${clean(act.storage[varname][key][0])})))`, `.Map`)
-      let storage = ((pass && !oog) ? (storage_pass + '\n _:Map') : (storage_fail + '\n _:Map' + '=> _'))
+            .map(key => `[${storagekeys(realname(varname), key)} <- (${clean(act.storage[varname][key][0])} => _)]`)
+            .join('        \n');
+      let storage = '        \n .Map \n' + ((pass && !oog) ? storage_pass : storage_fail) + '\n  _:Map \n';
 
     if(!(act.varname2alias[varname])) warn(`Implementation of variable "${varname} : address" not found!`);
     const alias = act.varname2alias[varname];

--- a/resources/rules.k.tmp
+++ b/resources/rules.k.tmp
@@ -7,19 +7,6 @@
     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
-    syntax Map ::= Map "+Map" Map [function] //concatenates two maps if their keys are disjoint
-
-    rule M +Map (K1 |-> V1) => M (K1 |-> V1)
-    requires notBool #inKeys(M, K1)
-
-    syntax Bool ::= #inKeys(Map, Int) [function]
-
-    rule #inKeys(.Map, KEY) => false
-    rule #inKeys((M:Map K0 |-> V0), K1) => true
-         requires K0 ==K K1
-    rule #inKeys((M:Map K0 |-> V0), K1) => #inKeys(M, K1)
-         requires K0 =/=K K1
-
     rule bool2Word(notBool(A ==K 0)) => A
          requires #rangeUInt(1, A)
 


### PR DESCRIPTION
With https://github.com/kframework/k/commit/d665d8c756efabe01b50a995f75723d6dcc7b448,
and since `MAP` module included in evm-semantics is the symbolic version, we no longer have to rely on our own `+Map` to ensure that things go wrong when there is a possible storage collision. An update to storage `M [K <- V]` will only simplify if K is provably not present in M. This was not the case before.