### PR TITLE
Add safety check around EVM-specific features

### DIFF
--- a/lib/behavior.js
+++ b/lib/behavior.js
@@ -88,9 +88,9 @@ const genBehaviour = (state, init = null) => {
       if(k) {
         evm = kast.get(k, "ethereum.evm");
         if(evm) {
-          node.revert = kast.get(evm, "statusCode").label == "EVMC_REVERT_NETWORK"
-          node.oog = kast.get(k, "statusCode").label == "EVMC_OUT_OF_GAS_NETWORK"
-          node.gas = kast.get(k, "callState.gas")
+            node.revert = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_REVERT_NETWORK";
+            node.oog = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_OUT_OF_GAS_NETWORK";
+            node.gas = kast.get(k, "ethereum.evm.callState.gas");
         }
       }
       if(circular[node]) node.status = "circular";

--- a/lib/behavior.js
+++ b/lib/behavior.js
@@ -86,9 +86,12 @@ const genBehaviour = (state, init = null) => {
       }
       let k = state.nodes[node.id.split("_")[0]];
       if(k) {
-        node.revert = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_REVERT_NETWORK"
-        node.oog = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_OUT_OF_GAS_NETWORK"
-        node.gas = kast.get(k, "ethereum.evm.callState.gas")
+        evm = kast.get(k, "ethereum.evm");
+        if(evm) {
+          node.revert = kast.get(evm, "statusCode").label == "EVMC_REVERT_NETWORK"
+          node.oog = kast.get(k, "statusCode").label == "EVMC_OUT_OF_GAS_NETWORK"
+          node.gas = kast.get(k, "callState.gas")
+        }
       }
       if(circular[node]) node.status = "circular";
       if(node.revert) {


### PR DESCRIPTION
With this fix klab inspection doesn't crash when certain EVM specific features are not present.