### PR TITLE
gas analyser: refund support (now everything is arrays)

### DIFF
--- a/haskell/src/Analyser.hs
+++ b/haskell/src/Analyser.hs
@@ -111,7 +111,7 @@ main = do
   args <- execParser opts
   s    <- inputToString $ gasInput args
   let maxG       = sufficientGas args
-      stratLabel = stratificationLabel args
+      tag        = stratificationLabel args
       laxOn      = laxMode args
       cosolveOn  = not $ noCosolveMode args
       stratifyOn = not $ noStratifyMode args
@@ -128,10 +128,10 @@ main = do
                        (True, False, False) -> coerce $ solve maxG g
                        (True, False, True)  -> coerce $ cosolve $ solve maxG g
                        _ -> error "error: illegal combination of flags."
-                     sm = stratify stratLabel solved
+                     sm = stratify solved
                      sm_result = encode $ StratifiedResult
-                       (unparse (Just sm) solved)
-                       (formatStratifiedSyntax sm)
+                       (unparse (Just (sm, tag)) solved)
+                       (formatStratifiedSyntax sm tag)
                      result = if stratifyOn
                               then sm_result
                               else C8.pack $ unparse Nothing solved

--- a/haskell/src/Analyser.hs
+++ b/haskell/src/Analyser.hs
@@ -15,7 +15,7 @@ import Options.Applicative
 import qualified Data.ByteString.Lazy.Char8 as C8
 
 import Gas       (coerce,
-                  unparse,
+                  showStratified,
                   stratify,
                   formatStratifiedSyntax)
 -- import Kast      (Kast)
@@ -133,9 +133,9 @@ main = do
       sm = stratify solved
       -- encode syntax with JSON
       smResult = encode $ StratifiedResult
-                  (unparse (Just (sm, tag)) solved)
+                  (showStratified (Just (sm, tag)) solved)
                   (formatStratifiedSyntax sm tag)
       result = if stratifyOn
                then smResult
-               else C8.pack $ unparse Nothing solved
+               else C8.pack $ showStratified Nothing solved
     in (C8.putStrLn result) >> exit

--- a/haskell/src/Kast.hs
+++ b/haskell/src/Kast.hs
@@ -14,7 +14,12 @@ data Kast = Kast {
   arity        :: Maybe Int,
   args         :: Maybe [Kast]
   } deriving (Generic, Eq, Show)
+
+data Kasts = Kasts [Kast]
+  deriving (Generic, Eq, Show)
+
 instance FromJSON Kast
+instance FromJSON Kasts
 
 -- raiseNothing :: MonadError e m => e -> Maybe a -> m a
 -- raiseNothing err x = case x of

--- a/haskell/src/KastParse.hs
+++ b/haskell/src/KastParse.hs
@@ -2,7 +2,6 @@
 module KastParse where
 
 import Control.Lens
-import Data.Either               (lefts, rights)
 import Data.List                 (intercalate, isPrefixOf, isSuffixOf)
 import qualified Data.Map.Strict as Map
 
@@ -12,108 +11,89 @@ import Kast
 -- instance has to live here because we need formatKast
 instance Show IntOrStartGasOrBlob where
   show (Basic n) = show n
-  show (Blob kast) = case formatKast kast of
-    Left e -> error e
-    Right fs -> view formula fs
+  show (Blob kast) = (formatKast kast) ^. formula
 
-
-
-
-kastToGasExpr :: Kast -> Either String (BasicGasExpr)
+kastToGasExpr :: Kast -> BasicGasExpr
 kastToGasExpr kast = case node kast of
   "KVariable" -> case originalName kast of
-    Nothing -> Left $ "KVariable missing originalName."
+    Nothing -> error "KVariable missing originalName."
     Just somevar ->  if "VGas" `isPrefixOf` somevar
-                     then Right $ Value StartGas
-                     else Left $ "Can't have variables in gas expressions, found: " ++ somevar
+                     then Value StartGas
+                     else error $ "Can't have variables in gas expressions, found: " ++ somevar
 
   "KToken" -> case sort kast of
-    Nothing -> Left $ "KToken missing sort."
-    Just "Int" -> Right $ Value $ Literal n
+    Nothing -> error "KToken missing sort."
+    Just "Int" -> Value $ Literal n
       where n = read t
             Just t = token kast
-    Just somesort -> Left $ "Can't have sorts other than Int, found: " ++ somesort
+    Just somesort -> error $ "Can't have sorts other than Int, found: " ++ somesort
 
   "KApply" -> case stripModuleTag <$> (label kast) of
-    Nothing -> Left "KApply missing label."
-    Just "_+Int_" -> let Just [arg1, arg2] = args kast in
-      case kastToGasExpr arg1 of
-        Left err -> Left err
-        Right e -> case kastToGasExpr arg2 of
-          Left err -> Left err
-          Right f -> Right $ Binary Add e f
+    Nothing -> error "KApply missing label."
+    Just "_+Int_" -> let Just [arg1, arg2] = args kast
+                         e = kastToGasExpr arg1
+                         f = kastToGasExpr arg2
+                     in Binary Add e f
+    Just "_-Int_" -> let Just [arg1, arg2] = args kast
+                         e = kastToGasExpr arg1
+                         f = kastToGasExpr arg2
+                     in Binary Sub e f
+    Just "_*Int_" -> let Just [arg1, arg2] = args kast
+                         e = kastToGasExpr arg1
+                         f = kastToGasExpr arg2
+                     in Binary Mul e f
 
-    Just "_-Int_" -> let Just [arg1, arg2] = args kast in
-      case kastToGasExpr arg1 of
-        Left err -> Left err
-        Right e -> case kastToGasExpr arg2 of
-          Left err -> Left err
-          Right f -> Right $ Binary Sub e f
+    Just "_/Int_" -> let Just [arg1, arg2] = args kast
+                         e = kastToGasExpr arg1
+      in case kastToGasExpr arg2 of
+           Value (Literal 64) -> Unary SixtyFourth e
+           n -> error $ "Gas expressions should have /64 only, found: /" ++ (show n)
+    Just "#if_#then_#else_#fi" ->
+      let Just [argc, arg1, arg2] = args kast
+          c = formatKast argc
+          e = kastToGasExpr arg1
+          f = kastToGasExpr arg2
+      in ITE (Cond c) e f
+    Just somelabel -> error $ "Unknown KApply in gas expression: " ++ somelabel
 
-    Just "_*Int_" -> let Just [arg1, arg2] = args kast in
-      case kastToGasExpr arg1 of
-        Left err -> Left err
-        Right e -> case kastToGasExpr arg2 of
-          Left err -> Left err
-          Right f -> Right $ Binary Mul e f
+  _ -> error "Unrecognised \"node\" in KAST."
 
-    Just "_/Int_" -> let Just [arg1, arg2] = args kast in
-      case kastToGasExpr arg1 of
-        Left err -> Left err
-        Right e -> case kastToGasExpr arg2 of
-          Left err -> Left err
-          Right (Value (Literal 64)) -> Right $ Unary SixtyFourth e
-          Right n -> Left $ "Gas expressions should have /64 only, found: /" ++ (show n)
-
-    Just "#if_#then_#else_#fi" -> let Just [arg_c, arg1, arg2] = args kast in
-      case kastToGasExpr arg1 of
-        Left err -> Left err
-        Right e -> case kastToGasExpr arg2 of
-          Left err -> Left err
-          Right f -> case formatKast arg_c of
-            Left err -> Left err
-            Right c -> Right $ ITE (Cond c) e f
-    Just somelabel -> Left $ "Unknown KApply in gas expression: " ++ somelabel
-  _ -> Left $ "Unrecognised \"node\" in KAST."
-
-formatKast :: Kast -> Either String FormulaicString
+formatKast :: Kast -> FormulaicString
 formatKast kast = case node kast of
   "KVariable" -> let Just var_name = originalName kast
                      -- K is the only supported type
                      Just var_type = Just "K"
-                 in Right $ FormulaicString var_name (at var_name ?~ var_type $ Map.empty)
+                 in FormulaicString var_name (at var_name ?~ var_type $ Map.empty)
 
   "KToken" -> let Just n = token kast
-      in Right $ FormulaicString n Map.empty
+      in FormulaicString n Map.empty
 
   "KApply" -> let Just func       = stripModuleTag <$> label kast
                   Just apply_args = args kast
-                  lr_fargs    = map formatKast apply_args
-                  fargs       = (^. formula) <$> rights lr_fargs
-                  fargs_types = Map.unions $ (^. types) <$> rights lr_fargs
-              in case lefts lr_fargs of
-                   err:_ -> Left err
-                   [] -> case formatKApply func fargs of
-                     Left err -> Left err
-                     Right x    -> Right $ FormulaicString x fargs_types
-  _ -> Left $ "Unrecognised \"node\" in KAST."
+                  fargs    = formatKast <$> apply_args
+                  fargs_forms = (^. formula) <$> fargs
+                  fargs_types = Map.unions $ (^. types) <$> fargs
+              in FormulaicString
+                  (formatKApply func fargs_forms)
+                  fargs_types
+  _ -> error "Unrecognised \"node\" in KAST."
 
-formatKApply :: String -> [String] -> Either String String
+formatKApply :: String -> [String] -> String
 formatKApply func fargs = let bracketed s = "( " ++ s ++ " )" in
   case (head func, last func, fargs) of
     -- binary infix
-    ('_', '_', (farg1:(farg2:[]))) -> Right $ bracketed $ farg1 ++ " " ++ func_trim ++ " " ++ farg2
+    ('_', '_', (farg1:(farg2:[]))) -> bracketed $ farg1 ++ " " ++ func_trim ++ " " ++ farg2
       where func_trim = tail $ init $ func
     -- unsupported mixfix
-    ('_', '_', _) -> Left $ "Couldn't parse mixfix operator: " ++ func
+    ('_', '_', _) -> error $ "Couldn't parse mixfix operator: " ++ func
     -- unary prefix
-    (_, '_', (farg:[])) -> Right $ bracketed $ func_trim ++ farg
+    (_, '_', (farg:[])) -> bracketed $ func_trim ++ farg
       where func_trim = init $ func
     -- unary postfix
-    ('_', _, (farg:[])) -> Right $ bracketed $ farg ++ func_trim
+    ('_', _, (farg:[])) -> bracketed $ farg ++ func_trim
       where func_trim = tail $ func
     -- n-ary prefix
-    (_, _, _) -> Right $ bracketed $ func_trim ++ (bracketed (intercalate " , " fargs))
+    (_, _, _) -> bracketed $ func_trim ++ (bracketed (intercalate " , " fargs))
       where func_trim = "`" ++ func ++ "`"
 
 -- the module names will be stripped from the labels

--- a/haskell/src/Solver.hs
+++ b/haskell/src/Solver.hs
@@ -170,8 +170,7 @@ solveLeaves :: Int -> BasicGasExpr -> ConstantGasExpr
 solveLeaves maxGas (ITE c e f) = ITE c e' f'
   where e' = solveLeaves maxGas e
         f' = solveLeaves maxGas f
-solveLeaves maxGas e =
-  Value maxOfMins
+solveLeaves maxGas e = Value maxOfMins
   where Just maxOfMins = maximumMay $ [minG]
                          ++ (catMaybes
                          $ (minimiseG maxGas)

--- a/haskell/src/Solver.hs
+++ b/haskell/src/Solver.hs
@@ -1,8 +1,6 @@
 module Solver where
 
 import Data.List  (drop, take)
-import Data.Maybe (catMaybes)
-import Safe       (maximumMay)
 
 import Gas
 
@@ -170,12 +168,8 @@ solveLeaves :: Int -> BasicGasExpr -> ConstantGasExpr
 solveLeaves maxGas (ITE c e f) = ITE c e' f'
   where e' = solveLeaves maxGas e
         f' = solveLeaves maxGas f
-solveLeaves maxGas e = Value maxOfMins
-  where Just maxOfMins = maximumMay $ [minG]
-                         ++ (catMaybes
-                         $ (minimiseG maxGas)
-                              <$> (findCallSubexprs e))
-        Just minG = minimiseG maxGas e
+solveLeaves maxGas e = Value minG
+  where Just minG = minimiseG maxGas e
 
 evalUnOp :: UnOp -> Int -> Int
 evalUnOp SixtyFourth x = quot x 64

--- a/lib/build.js
+++ b/lib/build.js
@@ -624,9 +624,12 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, gas_raw, splitNu
   const gasRewrite = "VGas => " + ((hasGas && !oog) ? gas_raw : "_");
   let gasCond;
   if (pass) {
-      gasCond = "VGas " + (oog ? "<Int " : ">=Int ") + gas
+      // TODO : oog?!
+      gasCond = (Array.isArray(gas) && gas || [gas])
+        .map(g => "VGas " + (oog ? "<Int " : ">=Int ") + g)
   } else if (!pass && !oog) {
-      gasCond = "VGas >=Int " + gas
+      gasCond = (Array.isArray(gas) && gas || [gas])
+        .map(g => "VGas >=Int " + g)
   }
 
   //The multiplication of the list monad
@@ -647,7 +650,7 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, gas_raw, splitNu
     })
     .concat(act.if || [])
     .concat(act.internal ? "#rangeUInt(256, VMemoryUsed)" : [])
-    .concat(gasCond ? [gasCond]: [])
+    .concat(gasCond ? gasCond : [])
     .concat((new Array(junk)).fill(1).map((a, i) => `#rangeUInt(256, Junk_${i})`))
   const pos_cond = (act_if || [])
     .concat(pass && act.iff || [])
@@ -776,8 +779,8 @@ const buildActs = (config, act_proofs) => {
       rough: false,
       hasGas: true,
       file_suffix: gas.stratification + "\n\n" + gas_raw.stratification,
-      gas: gas.constructor,
-      gas_raw: gas_raw.constructor
+      gas: gas.constructors,
+      gas_raw: gas_raw.constructors[0]
     };
 
     return {

--- a/libexec/klab-get-gas
+++ b/libexec/klab-get-gas
@@ -34,3 +34,6 @@ if [ $result -ne "0" ]; then
   exit 1;
 fi
 
+klab get-refund $spec_hash
+
+

--- a/libexec/klab-get-refund
+++ b/libexec/klab-get-refund
@@ -55,4 +55,6 @@ const refunds = refund_nodes
     return refund_gas;
   })
 
-fs.writeFileSync(path.join(KLAB_OUT, "gas", proofid + "_refunds.json"), JSON.stringify(refunds))
+const raw = JSON.parse(read(path.join(KLAB_OUT, "gas", proofid + ".raw.kast.json")));
+
+fs.writeFileSync(path.join(KLAB_OUT, "gas", proofid + ".all.json"), JSON.stringify([raw].concat(refunds)))

--- a/libexec/klab-solve-gas
+++ b/libexec/klab-solve-gas
@@ -26,17 +26,10 @@ fi
 
 name=$(cat "$KLAB_OUT/meta/data/$spec_hash"| jq -r ".name")
 
-
-if [ "$KLAB_LAX" ]; then
-    klab gas-analyser --input "$GAS_DIR/${spec_hash}.raw.kast.json" --lax > "$GAS_DIR/${spec_hash}.kast"
-    result=$?
-else
-  klab gas-analyser --stratification-label $name --input "$GAS_DIR/${spec_hash}.raw.kast.json" > "$GAS_DIR/${spec_hash}.kast"
-  result_solved=$?
-  klab gas-analyser --no-solve --stratification-label ${name}_raw --input "$GAS_DIR/${spec_hash}.raw.kast.json" > "$GAS_DIR/${spec_hash}.raw.kast"
-  result_raw=$?
-fi
-
+klab gas-analyser --stratification-label $name --input "$GAS_DIR/${spec_hash}.all.json" > "$GAS_DIR/${spec_hash}.kast"
+result_solved=$?
+klab gas-analyser --no-solve --stratification-label ${name}_raw --input "$GAS_DIR/${spec_hash}.all.json" > "$GAS_DIR/${spec_hash}.raw.kast"
+result_raw=$?
 
 if [ $result_solved -ne "0" ] || [ $result_raw -ne "0" ]; then
   rm "$GAS_DIR/${spec_hash}.kast"

--- a/resources/rules.k.tmp
+++ b/resources/rules.k.tmp
@@ -68,9 +68,9 @@
 
     rule #lookup( (KEY |-> VAL) M, KEY ) => VAL
     rule #lookup(               M, KEY ) => 0 requires notBool KEY in_keys(M)
-        
+
     rule #range(WM, START, WIDTH) => #range(WM, START +Int WIDTH -Int 1, WIDTH, .WordStack)
-    
+
     rule WM[ N := W : WS     ] => (WM[N <- W])[N +Int 1 := WS]
 
     //semantics of #buf
@@ -344,7 +344,7 @@ rule ACCTCODE in SetItem( 1 )
 
     rule #if C #then (#if C #then B1 #else B2 #fi) -Int D #else (#if C #then B3 #else B4 #fi) -Int E #fi =>
          #if C #then B1 -Int D #else B4 -Int E #fi
-    
+
 
     rule A -Int A => 0
 
@@ -476,3 +476,9 @@ rule <k> ECREC => #end EVMC_SUCCESS ... </k>
 [trusted]
 
 rule #memoryUsageUpdate(MU, START, WIDTH) => maxInt(MU, (START +Int WIDTH) up/Int 32) requires WIDTH  >Int 0
+
+// GAS optimisation
+rule ((A -Int (X +Int C)) +Int (C -Int Y)) => (A -Int X) -Int Y
+
+rule #if C #then G -Int X #else G -Int Y #fi => G -Int (#if C #then X #else Y #fi)
+


### PR DESCRIPTION
Now we just need @mhhf to integrate this with `klab`.

n.b. that the input is now expected to be a JSON array of raw gas
kasts, and the output will always be in array form.

With stratification (the default), the "constructors" field (which
used to be called "constructor") will be an array of strings like
`["#G0", "#G1", ..., "#Gn"]`, and should be interpreted as a list of
lower bounds for the initial gas, i.e. should translate into a
condition like `(VGas >=Int #G0) andBool ... andBool (VGas >=Int #Gn)`.

With the flag `--no-stratify`, the output will be an array of strings,
corresponding to the unstratified gas expressions.