### PR TITLE
gas analyser: propagate unknown `KVariable`s and `KApply`s

### DIFF
--- a/haskell/src/Kast.hs
+++ b/haskell/src/Kast.hs
@@ -13,7 +13,7 @@ data Kast = Kast {
   variable     :: Maybe Bool,
   arity        :: Maybe Int,
   args         :: Maybe [Kast]
-  } deriving (Generic, Eq, Show)
+  } deriving (Generic, Eq, Ord, Show)
 
 data Kasts = Kasts [Kast]
   deriving (Generic, Eq, Show)


### PR DESCRIPTION
This adds support for unknown `KVariable`s and `KApply`s for parsing, stratifying, and solving. Note that the numerical solution method is not capable of handling expressions containing unknowns, limting the capabilities of the solver in those cases.