### PR TITLE
remove 'v' as it isn't in current tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ to make them get along.
 
 ### Building
 
-Clone the repo and install the latest stable version `v0.3` with
+Clone the repo and install the latest stable version `0.3` with
 ```sh
-git clone --branch v0.3 https://github.com/dapphub/klab.git
+git clone --branch 0.3 https://github.com/dapphub/klab.git
 cd klab
 make deps
 ```


### PR DESCRIPTION
This causes naively running the command in the README to fail.