### PR TITLE
Add error for bad klab evms path

### DIFF
--- a/libexec/klab-build-js
+++ b/libexec/klab-build-js
@@ -64,6 +64,9 @@ var {rules_str} = makeRules(config);
 const {prelude_str, write_prelude} = makePrelude(config);
 // TODO error when not set
 const KLAB_EVMS_PATH = process.env.KLAB_EVMS_PATH || path.join(__dirname, '..', 'evm-semantics');
+if ('evm-semantics' !== KLAB_EVMS_PATH.match(/([^\/]*)\/*$/)[1]) {
+  throw new Error(`Wrong EVMS path: ${KLAB_EVMS_PATH}`);
+}
 const EVM_SEMANTICS_VERSION = execSync(`git rev-parse HEAD`, {
   cwd: KLAB_EVMS_PATH,
   encoding: 'utf8'

--- a/libexec/klab-report
+++ b/libexec/klab-report
@@ -20,6 +20,9 @@ const {
 const fs     = require("fs");
 const KLAB_OUT      = process.env.KLAB_OUT || "out";
 const KLAB_EVMS_PATH = process.env.KLAB_EVMS_PATH || path.join(__dirname, '..', 'evm-semantics');
+if ('evm-semantics' !== KLAB_EVMS_PATH.match(/([^\/]*)\/*$/)[1]) {
+  throw new Error(`Wrong EVMS path: ${KLAB_EVMS_PATH}`);
+}
 const EVM_SEMANTICS_VERSION = execSync(`git rev-parse HEAD`, {
   cwd: KLAB_EVMS_PATH,
   encoding: 'utf8'


### PR DESCRIPTION
Adding an error throw if `KLAB_EVMS_PATH` does not end in `evm-semantics`