### PR TITLE
Use Node 10

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ stdenv.mkDerivation {
     maven
     mpfr
     ncurses
-    nodejs-8_x
+    nodejs-10_x
     opam
     openjdk8
     pandoc


### PR DESCRIPTION
`nodejs-8_x` is not recognized anymore (I'm using Nix 2.3 installed today). Updating to `nodejs-10_x` although 11 or 12 could be used too (haven't tested them).