### PR TITLE
Update for MacOS installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On OSX, using Homebrew, after installing the command line tools package:
 
 ```sh
 brew tap homebrew/cask-versions
-brew cask install caskroom/versions/java8
+brew cask install adoptopenjdk/openjdk/adoptopenjdk8
 brew install automake libtool gmp mpfr pkg-config pandoc maven opam z3 node gnu-getopt jq
 ```
 This project uses the `GNU` version of `getopt` and `time`. `OSX` and `gnu` have a complicated relationship but you can run:

--- a/README.md
+++ b/README.md
@@ -9,27 +9,8 @@ Installation
 
 ### Dependencies
 
-Installing klab automatically installs `K` and `KEVM`. You will therefore need the dependencies of K.
+[See dependency installation instructions here](https://github.com/kframework/evm-semantics#system-dependencies)
 
-To install all of these dependencies on Ubuntu, try:
-
-```sh
-sudo apt-get install make gcc maven openjdk-8-jdk flex pkg-config libmpfr-dev autoconf libtool pandoc zlib1g-dev z3 libz3-dev npm parallel gnu-time jq
-```
-
-On ArchLinux:
-
-```sh
-sudo pacman -S  base-devel rsync opam pandoc jre8-openjdk mpfr maven z3 nodejs npm parallel
-```
-
-On OSX, using Homebrew, after installing the command line tools package:
-
-```sh
-brew tap homebrew/cask-versions
-brew cask install adoptopenjdk/openjdk/adoptopenjdk8
-brew install automake libtool gmp mpfr pkg-config pandoc maven opam z3 node gnu-getopt jq
-```
 This project uses the `GNU` version of `getopt` and `time`. `OSX` and `gnu` have a complicated relationship but you can run:
 ```sh
 export PATH=/usr/local/opt/gnu-getopt/bin:/usr/local/opt/gnu-time/libexec/gnubin:$PATH


### PR DESCRIPTION
Oracle distribution of "java8" has ceased to be available: https://stackoverflow.com/questions/55834845/unable-to-install-java8-with-homebrew

Repointing cask installation to https://github.com/AdoptOpenJDK/homebrew-openjdk

