### PR TITLE
Source from repo env instead of path env

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ PREFIX=/path/to/custom/prefix make link
 The file `env` will setup the environment for you if sourced from the root directory of the repo.
 
 ```sh
-source env
+source ./env
 ```
 
 It sets three environment variables:


### PR DESCRIPTION
Add a `/` to specify that source should look for the local `env` file, rather than the one on the path.