### PR TITLE
Support waffle based build systems

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -219,8 +219,7 @@ const make_args = inputs => inputs && inputs.length == 0
     || inputs.map(make_abi_dsl).join(", ")
 
 const makeInterabiExhaustiveness = (alias, cname, contract) => {
-
-  const if_not_entries = JSON.parse(contract.abi)
+  const if_not_entries = contract.abi
     .filter(fabi => fabi.type == "function")
     .map(fabi => sha3(fabi.name + `(${fabi.inputs.map(i => i.type).join(",")})`).slice(0, 8))
     .map(fabis => parseInt(fabis, 16).toString())

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,8 +15,9 @@ const {
 const toJson = str => JSON.parse(str);
 
 module.exports = (json) => {
-  const dappout = `${json.dapp_root}/out/dapp.sol.json`
-  if (!testPath(dappout)) revert(`Dapp json not found: ${dappout}`)
+  if (!("solc_output_path" in json)) json.solc_output_path = "out/dapp.sol.json"
+  const dappout = `${json.dapp_root}/${json.solc_output_path}`
+  if (!testPath(dappout)) revert(`solc json output not found: ${dappout}`)
   const dapp = toJson(read(dappout))
 
   const contracts = {};
@@ -35,7 +36,7 @@ module.exports = (json) => {
       if (!contract) revert(`No contract named ${fullname} found in ${dappout}`)
 
       const ast = dapp.sources[src].AST
-      const abi = contract["abi"]
+      const abi = typeof(contract["abi"]) === "string" ? JSON.parse(contract["abi"]) : contract["abi"]
       const bin_runtime = contract["bin-runtime"]
       const srcmap_runtime = contract["srcmap-runtime"]
 

--- a/libexec/klab-report
+++ b/libexec/klab-report
@@ -208,7 +208,7 @@ const genCoverageReport = (proofs) => {
   const coverage = Object.keys(config.contracts)
     .map(contract_name => {
       const c = config.contracts[contract_name];
-      const abi_signatures = JSON.parse(c.abi)
+      const abi_signatures = c.abi
         .filter(fabi => fabi.type == 'function')
         .map(fabi => `${fabi.name}(${fabi.inputs.map(i => i.type).join(',')})`);
 


### PR DESCRIPTION
A couple of small changes that let `klab` play nice with [waffle](https://github.com/EthWorks/Waffle) based projects.

- add a `solc_output` key to the config.json to allow integration with build systems that name their solc json output something other than `dapp.sol.json`

- handle both stringified and non stringified abi specifications in solc output (contract abis generated by waffle according to the instructions [here](https://ethereum-waffle.readthedocs.io/en/latest/configuration.html#klab-compatibility) are not stringified, those output with `solc --combined-json=abi,bin,bin-runtime,srcmap,srcmap-runtime,ast` are).

Having `klab` support multiple json output formats is kinda messy, but I played around with the various options for a while and couldn't figure out how to bring it inline with the json produced by `dapp`. If someone knows how I would be happy to remove the extra code here.

**tests performed**

- `make test`
- `klab build && klab prove --dump <SPEC>` in both `k-dss` and a waffle based project.