### PR TITLE
shell.nix: pin to nixos-19.09

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,10 @@
-with import <nixpkgs> {};
+with import (builtins.fetchGit rec {
+  name = "nixpkgs-19.09-${rev}";
+  url = https://github.com/nixos/nixpkgs;
+  ref = "nixos-19.09";
+  # git ls-remote https://github.com/nixos/nixpkgs-channels nixos-19.09
+  rev = "9f453eb97ffe261ff93136757cd08b522fac83b7";
+}) {};
 stdenv.mkDerivation {
   name = "klab-env";
   buildInputs = [


### PR DESCRIPTION
`klab` is currently broken with `nixpkgs@unstable` (see https://github.com/dapphub/klab/issues/295). This commit pins us to a known good revision of `nixos-19.09` in `shell.nix`