### PR TITLE
k.json: add BLOCK_NUMBER

### DIFF
--- a/resources/k.json
+++ b/resources/k.json
@@ -42,7 +42,7 @@
         "receiptsRoot": "_",
         "logsBloom": "_",
         "difficulty": "_",
-        "number": "_",
+        "number": "BLOCK_NUMBER",
         "gasLimit": "_",
         "gasUsed": "_",
         "timestamp": "TIME",


### PR DESCRIPTION
Allow usage of `BLOCK_NUMBER` in `act` specs to refer to `block.number`