### PR TITLE
RFC: act: multiline statments

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -260,6 +260,7 @@ const makeInterabiExhaustiveness = (alias, cname, contract) => {
 
 const parseAct = config => (act_str, silent = false) => {
   let _act = act_str
+    .replace(/ \\\n/gm, "") // allow for simple bash style line continuations
     .split("\n")
     .reduce(([c, a], l) => {
       if(/^[^\s]/.test(l)) {


### PR DESCRIPTION
Maybe there is a cleaner way to do this, but with this change I can split very long `K` statements (especially `#if ... #then ... #else ... #fi` blocks) over multiple lines, so something like:

```
storage
    value |-> Value => #if Condition1 =/= 0 and Condition2 =/= 0  #then Value +Int (pow32 &Int OtherValue) /Int YetAnotherValue #else Value #fi
```

becomes

```
storage
    value |-> Value => #if Condition1 =/= 0 and Condition2 =/= 0  \
      #then Value +Int (pow32 &Int OtherValue) /Int YetAnotherValue \
      #else Value \
    #fi
```