### PR TITLE
shell.nix: bump memory cap to 4GiB

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -36,5 +36,6 @@ stdenv.mkDerivation {
   shellHook = ''
     export PATH=$PWD/node_modules/.bin/:$PWD/bin:$PATH
     export KLAB_EVMS_PATH="''${KLAB_EVMS_PATH:-''${PWD}/evm-semantics}"
+    export NODE_OPTIONS="--max-old-space-size=4096"
   '';
 }


### PR DESCRIPTION
Cf. https://stackoverflow.com/questions/38558989/node-js-heap-out-of-memory

Only in `shell.nix` for now. If this turns out to be very useful we can move it to klab proper.