### PR TITLE
allow address(0)

### DIFF
--- a/resources/rules.k.tmp
+++ b/resources/rules.k.tmp
@@ -492,7 +492,7 @@ rule A modInt pow160 => A
 
 syntax Bool ::= #notPrecompileAddress ( Int ) [function]
 // ---------------------------------------
-rule #notPrecompileAddress ( X ) => 0 <Int X andBool 9 <=Int X andBool #rangeAddress(X)
+rule #notPrecompileAddress ( X ) => 0 <=Int X andBool 9 <=Int X andBool #rangeAddress(X)
 
 // ABSTRACT SEMANTICS.k
 


### PR DESCRIPTION
Adjust the `#notPrecompileAddress` range so that it doesn't
interfere with zero equality.