### PR TITLE
README.md: just instruct the user to use master

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ to make them get along.
 
 ### Building
 
-Clone the repo and install the latest stable version `0.3` with
+Clone the repo and install the latest `master` with
 ```sh
-git clone --branch 0.3 https://github.com/dapphub/klab.git
+git clone https://github.com/dapphub/klab.git
 cd klab
 make deps
 ```


### PR DESCRIPTION
We experimented with stable releases for a while but I think the most manageable thing is to just instruct users to use `master`.

If certain projects require an older version of `klab` then they should specify themselves which revision to use.