### PR TITLE
nix: allow consuming projects to reuse our nixpkgs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,13 +1,16 @@
-with import (builtins.fetchGit rec {
-  name = "nixpkgs-19.09-${rev}";
-  url = https://github.com/nixos/nixpkgs;
-  ref = "nixos-19.09";
-  # git ls-remote https://github.com/nixos/nixpkgs-channels nixos-19.09
-  rev = "9f453eb97ffe261ff93136757cd08b522fac83b7";
-}) {};
-stdenv.mkDerivation {
+let
+  pkgs = import (builtins.fetchGit rec {
+    name = "nixpkgs-19.09-${rev}";
+    url = https://github.com/nixos/nixpkgs;
+    ref = "nixos-19.09";
+    # git ls-remote https://github.com/nixos/nixpkgs-channels nixos-19.09
+    rev = "9f453eb97ffe261ff93136757cd08b522fac83b7";
+  }) {};
+in
+pkgs.stdenv.mkDerivation {
+  passthru = { inherit pkgs; };
   name = "klab-env";
-  buildInputs = [
+  buildInputs = with pkgs; [
     autoconf
     bc
     flex


### PR DESCRIPTION
Adds `pkgs` to the `passthru`, making it available for projects importing `shell.nix`.

This allows them to ensure they are always using the "official" nixpkgs version for `klab`.