### PR TITLE
Makefile: build haskell dependencies by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ yellow:=$(shell tput setaf 3)
 bold:=$(shell tput bold)
 reset:=$(shell tput sgr0)
 
-default: deps
+default: deps deps-haskell
 
 clean:
 	rm -fdR out/* evm-semantics


### PR DESCRIPTION
They're needed for the gas analyzer, which is almost always used.