### PR TITLE
rules.k.tmp: allow address(0)

### DIFF
--- a/resources/rules.k.tmpl
+++ b/resources/rules.k.tmpl
@@ -492,7 +492,7 @@ rule A modInt pow160 => A
 
 syntax Bool ::= #notPrecompileAddress ( Int ) [function]
 // ---------------------------------------
-rule #notPrecompileAddress ( X ) => 0 <Int X andBool 9 <=Int X andBool #rangeAddress(X)
+rule #notPrecompileAddress ( X ) => notBool #range(1 <= X <= 9) andBool #rangeAddress(X)
 
 // ABSTRACT SEMANTICS.k
 


### PR DESCRIPTION
Adjust the notPrecompileAddress range so that it doesn't
interfere with zero equality.

Prior to this change, declaring a zero constraint on an
address type would throw an assertion error.