### PR TITLE
README: mention v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ to make them get along.
 
 ### Building
 
-Clone the repo and install the latest stable version `0.3` with
+Clone the repo and install the latest stable version `v0.4.0` with
 ```sh
-git clone --branch 0.3 https://github.com/dapphub/klab.git
+git clone --branch v0.4.0 https://github.com/dapphub/klab.git
 cd klab
 make deps
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ to make them get along.
 
 ### Building
 
-Clone the repo and install the latest `master` with
+Clone the repo and install the latest stable version `0.3` with
 ```sh
-git clone https://github.com/dapphub/klab.git
+git clone --branch 0.3 https://github.com/dapphub/klab.git
 cd klab
 make deps
 ```


### PR DESCRIPTION
This reverts commit f31e24e0da5746f69e57f362445765210f6ae484.

The reason is that klab master is currently partially broken after merging #318.