### PR TITLE
view: check endheight is defined

### DIFF
--- a/lib/view.js
+++ b/lib/view.js
@@ -16,7 +16,7 @@ const makeStatus = (o) => {
   const getHeights = b => [b.endheight].concat(b.children.map(getHeights).reduce((a,c) => a.concat(c), []))
 
   const max_step = o.behaviour &&
-    Math.max.apply(null, o.behaviour && getHeights(o.behaviour) || [0])
+    Math.max.apply(null, o.behaviour.endheight && getHeights(o.behaviour) || [0])
 
   const step_str = o.path.length > 0
     ? " " + ((o.path.length > 1 ? o.path.slice(-2, -1)[0].height : 0 ) + o.path.slice(-1)[0].count)  + "/" + max_step + " "


### PR DESCRIPTION
This fixes a case in which the `max_step` was `NaN`.

This is a hack, since `getHeights` gets called recursively and it might
therefore be necessary to check for the property's existence in
`getHeights` itself.