### PR TITLE
klab-setup-ci-project: make deploys easier

### DIFF
--- a/libexec/klab-prove-all
+++ b/libexec/klab-prove-all
@@ -42,7 +42,6 @@ if [ -d ".git" ]; then
   if [ -n "$KLAB_REPORT_DIR" ]; then
     export KLAB_REPORT_NAME_DIR=$KLAB_REPORT_DIR/$PNAME
     export KLAB_REPORT_PROJECT_DIR=$KLAB_REPORT_DIR/$PNAME/$build_hash
-    mkdir -p "$KLAB_REPORT_PROJECT_DIR"
     if [ -n "$PNAME" ]; then
       klab setup-ci-project --no-overwrite --report-dir "${KLAB_REPORT_DIR}" --project-name "${PNAME}"
     fi;

--- a/libexec/klab-prove-all
+++ b/libexec/klab-prove-all
@@ -44,7 +44,7 @@ if [ -d ".git" ]; then
     export KLAB_REPORT_PROJECT_DIR=$KLAB_REPORT_DIR/$PNAME/$build_hash
     mkdir -p "$KLAB_REPORT_PROJECT_DIR"
     if [ -n "$PNAME" ]; then
-      klab setup-ci-project "$PNAME"
+      klab setup-ci-project --no-overwrite --report-dir "${KLAB_REPORT_DIR}" --project-name "${PNAME}"
     fi;
     if [ ! -f "$KLAB_REPORT_DIR/$PNAME"/report.json ]; then
       echo "{}" > "$KLAB_REPORT_DIR/$PNAME"/report.json

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -16,5 +16,7 @@ node-sass "${resources_path}" -o "${resources_path}" --source-map true
 cp $no_overwrite -t "${KLAB_REPORT_DIR}" "${resources_path}"/{overview.css,overview.js,report.css}
 
 if [[ -n $PROJECT_NAME ]]; then
-    cp $no_overwrite "${resources_path}/overview.html" "${KLAB_REPORT_DIR}/${PROJECT_NAME}/index.html"
+    PROJECT_DIR="${KLAB_REPORT_DIR}/${PROJECT_NAME}"
+    mkdir -p "${PROJECT_DIR}"
+    cp $no_overwrite "${resources_path}/overview.html" "${PROJECT_DIR}/index.html"
 fi

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -2,10 +2,10 @@
 
 resources_path=$(dirname "${BASH_SOURCE}")/../resources
 
-cp -n $resources_path/overview.css "$KLAB_REPORT_DIR"
-cp -n $resources_path/overview.js "$KLAB_REPORT_DIR"
-cp -n $resources_path/report.css "$KLAB_REPORT_DIR"
+cp -n "${resources_path}/overview.css" "${KLAB_REPORT_DIR}"
+cp -n "${resources_path}/overview.js" "${KLAB_REPORT_DIR}"
+cp -n "${resources_path}/report.css" "${KLAB_REPORT_DIR}"
 
 if [[ $# -gt 1 ]]; then
-    cp -n $resources_path/overview.html "$KLAB_REPORT_DIR"/"$1"/index.html
+    cp -n "${resources_path}/overview.html" "${KLAB_REPORT_DIR}/$1/index.html"
 fi

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -2,7 +2,7 @@
 
 while [[ $1 ]]; do
     case "$1" in
-        --no-overwrite) no_overwrite="-n"; shift;;
+        --no-overwrite) overwrite_opt="-n"; shift;;
         --report-dir) shift; KLAB_REPORT_DIR=$1; shift;;
         --project-name) shift; PROJECT_NAME=$1; shift;;
         *) echo Unrecognized argument "$1"; exit 1;;
@@ -14,10 +14,10 @@ resources_path=$(dirname "${BASH_SOURCE}")/../resources
 node-sass "${resources_path}" -o "${resources_path}" --source-map true
 
 mkdir -p "${KLAB_REPORT_DIR}"
-cp $no_overwrite -t "${KLAB_REPORT_DIR}" "${resources_path}"/{overview.css,overview.js,report.css}
+cp $overwrite_opt -t "${KLAB_REPORT_DIR}" "${resources_path}"/{overview.css,overview.js,report.css}
 
 if [[ -n $PROJECT_NAME ]]; then
     PROJECT_DIR="${KLAB_REPORT_DIR}/${PROJECT_NAME}"
     mkdir -p "${PROJECT_DIR}"
-    cp $no_overwrite "${resources_path}/overview.html" "${PROJECT_DIR}/index.html"
+    cp $overwrite_opt "${resources_path}/overview.html" "${PROJECT_DIR}/index.html"
 fi

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 
+while [[ $1 ]]; do
+    case "$1" in
+        --no-overwrite) no_overwrite="-n"; shift;;
+        --report-dir) shift; KLAB_REPORT_DIR=$1; shift;;
+        --project-name) shift; PROJECT_NAME=$1; shift;;
+        *) echo Unrecognized argument "$1"; exit 1;;
+    esac
+done
+
 resources_path=$(dirname "${BASH_SOURCE}")/../resources
 
 node-sass "${resources_path}" -o "${resources_path}" --source-map true
 
-cp -n -t "${KLAB_REPORT_DIR}" "${resources_path}/{overview.css,overview.js,report.css}"
+cp $no_overwrite -t "${KLAB_REPORT_DIR}" "${resources_path}"/{overview.css,overview.js,report.css}
 
-if [[ $# -gt 1 ]]; then
-    cp -n "${resources_path}/overview.html" "${KLAB_REPORT_DIR}/$1/index.html"
+if [[ -n $PROJECT_NAME ]]; then
+    cp $no_overwrite "${resources_path}/overview.html" "${KLAB_REPORT_DIR}/${PROJECT_NAME}/index.html"
 fi

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -5,4 +5,7 @@ resources_path=$(dirname "${BASH_SOURCE}")/../resources
 cp -n $resources_path/overview.css "$KLAB_REPORT_DIR"
 cp -n $resources_path/overview.js "$KLAB_REPORT_DIR"
 cp -n $resources_path/report.css "$KLAB_REPORT_DIR"
-cp -n $resources_path/overview.html "$KLAB_REPORT_DIR"/"$1"/index.html
+
+if [[ $# -gt 1 ]]; then
+    cp -n $resources_path/overview.html "$KLAB_REPORT_DIR"/"$1"/index.html
+fi

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -3,9 +3,8 @@
 resources_path=$(dirname "${BASH_SOURCE}")/../resources
 
 node-sass "${resources_path}" -o "${resources_path}" --source-map true
-cp -n "${resources_path}/overview.css" "${KLAB_REPORT_DIR}"
-cp -n "${resources_path}/overview.js" "${KLAB_REPORT_DIR}"
-cp -n "${resources_path}/report.css" "${KLAB_REPORT_DIR}"
+
+cp -n -t "${KLAB_REPORT_DIR}" "${resources_path}/{overview.css,overview.js,report.css}"
 
 if [[ $# -gt 1 ]]; then
     cp -n "${resources_path}/overview.html" "${KLAB_REPORT_DIR}/$1/index.html"

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -13,6 +13,7 @@ resources_path=$(dirname "${BASH_SOURCE}")/../resources
 
 node-sass "${resources_path}" -o "${resources_path}" --source-map true
 
+mkdir -p "${KLAB_REPORT_DIR}"
 cp $no_overwrite -t "${KLAB_REPORT_DIR}" "${resources_path}"/{overview.css,overview.js,report.css}
 
 if [[ -n $PROJECT_NAME ]]; then

--- a/libexec/klab-setup-ci-project
+++ b/libexec/klab-setup-ci-project
@@ -2,6 +2,7 @@
 
 resources_path=$(dirname "${BASH_SOURCE}")/../resources
 
+node-sass "${resources_path}" -o "${resources_path}" --source-map true
 cp -n "${resources_path}/overview.css" "${KLAB_REPORT_DIR}"
 cp -n "${resources_path}/overview.js" "${KLAB_REPORT_DIR}"
 cp -n "${resources_path}/report.css" "${KLAB_REPORT_DIR}"


### PR DESCRIPTION
The idea with this PR is that the `prove-all` command keeps on working as before (i.e. it only copies files if they're not there already), because we don't want a local klab (e.g. in k-dss) to overwrite global reports dirs.

OTOH, the `klab-setup-ci-project` script can be run on a new CI (without the `--project-name` argument) to actually set up a CI for the first time - or to make global changes. In our buildbot case, this would look like:

```bash
$ cd klab && nix-shell
$ klab-setup-ci-project --report-dir /var/publish/reports
```

We could add this to the `Makefile`, theoretically,

This PR also adds SCSS asset pre-processing.