### PR TITLE
klab-prove: add debug-z3 flag

### DIFF
--- a/libexec/klab-prove
+++ b/libexec/klab-prove
@@ -133,6 +133,7 @@ timeout "$TIMEOUT" "$KLAB_EVMS_PATH/deps/k/k-distribution/target/release/k/bin/k
   --smt_prelude "$KLAB_OUT/prelude.smt2" \
   --concrete-rules "$(join_by , ${concrete_rules[@]})" \
   --z3-tactic "(or-else (using-params smt :random-seed 3) (using-params smt :random-seed 2) (using-params smt :random-seed 1))" \
+  --debug-z3 \
   "$target_spec" >"$STDOUT" 2>"$STDERR" & kprove_child=$!
 wait "$kprove_child"
 result=$?

--- a/libexec/klab-prove
+++ b/libexec/klab-prove
@@ -82,7 +82,7 @@ if $dump; then
 fi
 
 if $kdebug; then
-  K_FLAGS=("$K_FLAGS" --debug)
+  K_FLAGS=("$K_FLAGS" --debug --debug-z3)
 fi
 
 function join_by { local IFS="$1"; shift; echo "$*"; }
@@ -133,7 +133,6 @@ timeout "$TIMEOUT" "$KLAB_EVMS_PATH/deps/k/k-distribution/target/release/k/bin/k
   --smt_prelude "$KLAB_OUT/prelude.smt2" \
   --concrete-rules "$(join_by , ${concrete_rules[@]})" \
   --z3-tactic "(or-else (using-params smt :random-seed 3) (using-params smt :random-seed 2) (using-params smt :random-seed 1))" \
-  --debug-z3 \
   "$target_spec" >"$STDOUT" 2>"$STDERR" & kprove_child=$!
 wait "$kprove_child"
 result=$?


### PR DESCRIPTION
Prints out useful information, like the following, plus a bunch of other stuff.

Produces *really huge* logs (~18MB on `token0`).

### Samples

```
[nix-shell:~/code/dapphub/k-uniswap-v2]$ klab prove --kdebug UniswapV2Exchange_token0_pass_rough
Using evm-semantics from /home/asymmetric/code/dapphub/k-uniswap-v2/deps/klab/evm-semantics
Proof STARTING: abf7e62979d0976a6af1ad21b44b576336368cec815dfda2419e70c36b127f6e.k [UniswapV2Exchange_token0_pass_rough]
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/././out/specs/abf7e62979d0976a6af1ad21b44b576336368cec815dfda2419e70c36b127f6e.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/out/specs/abf7e62979d0976a6af1ad21b44b576336368cec815dfda2419e70c36b127f6e.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/out/rules.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/deps/klab/evm-semantics/.build/defn/java/edsl.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/deps/klab/evm-semantics/.build/defn/java/evm.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/deps/klab/evm-semantics/.build/defn/java/data.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/deps/klab/evm-semantics/.build/defn/java/krypto.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/deps/klab/evm-semantics/.build/defn/java/network.k)
Importing: Source(/home/asymmetric/code/dapphub/k-uniswap-v2/out/bin_runtime.k)
```

```
Z3 query result: unknown

Z3 Implication (Function rule implication) failed:
ConjunctiveFormula(
)
  implies
ConjunctiveFormula(
  equalities:
    _==K_(_==K_(W:Int,, Int(#"0")),, Bool(#"false"))
)

Rule for formula above:
    rule bool2Word( B:Bool ) => 0 requires notBool B
	Source: /home/asymmetric/k-uniswap-v2/deps/klab/evm-semantics/.build/defn/java/evm-types.k Location(138,10,138,53)
```

```
[Error] Critical:  (null)
  while evaluating function sizeWordStackAux * 78
  while evaluating functional term:
        sizeWordStackAux(_:_WS(Int(#"80"),, _:_WS(Int(#"85"),, _:_WS(Int(#"84"),, _:_WS(Int(#"95"),, _:_WS(Int(#"65"),, _:_WS(Int(#"77"),, _:_WS(Int(#"79"),, _:_WS(Int(#"85"),, _:_WS(Int(#"78"),, _:_WS(Int(#"84"),
, _:_WS(Int(#"85"),, _:_WS(Int(#"110"),, _:_WS(Int(#"105"),, _:_WS(Int(#"115"),, _:_WS(Int(#"119"),, _:_WS(Int(#"97"),, _:_WS(Int(#"112"),, _:_WS(Int(#"86"),, _:_WS(Int(#"50"),, _:_WS(Int(#"58"),, _:_WS(Int(#"32")
,, _:_WS(Int(#"73"),, _:_WS(Int(#"78"),, _:_WS(Int(#"83"),, _:_WS(Int(#"85"),, _:_WS(Int(#"70"),, _:_WS(Int(#"70"),, _:_WS(Int(#"73"),, _:_WS(Int(#"67"),, _:_WS(Int(#"73"),, _:_WS(Int(#"69"),, _:_WS(Int(#"78"),, _
:_WS(Int(#"84"),, _:_WS(Int(#"95"),, _:_WS(Int(#"76"),, _:_WS(Int(#"73"),, _:_WS(Int(#"81"),, _:_WS(Int(#"85"),, _:_WS(Int(#"73"),, _:_WS(Int(#"68"),, _:_WS(Int(#"73"),, _:_WS(Int(#"84"),, _:_WS(Int(#"89"),, _:_WS
(Int(#"85"),, _:_WS(Int(#"110"),, _:_WS(Int(#"105"),, _:_WS(Int(#"115"),, _:_WS(Int(#"119"),, _:_WS(Int(#"97"),, _:_WS(Int(#"112"),, _:_WS(Int(#"86"),, _:_W...
  and applying the rule
    rule #sizeWordStack ( WS , N:Int )
      => #sizeWordStack ( WS , 0 ) +Int N
      requires N =/=K 0
        Source: /run/user/1001/tmp.erwpHpFtn9/rules.k Location(489,10,491,24)
```

Introduced in https://github.com/kframework/k/commit/b82b6a056c296654d2a99a40465445d8616083c7.