### PR TITLE
Remove additional sizeWordStack rules

### DIFF
--- a/resources/rules.k.tmpl
+++ b/resources/rules.k.tmpl
@@ -246,6 +246,7 @@ rule ACCTCODE in SetItem( 1 )
      requires D modInt 8 ==Int 0 andBool D >=Int 0
        andBool #sizeWordStack(WS) >=Int (D /Int 8)
        andBool #sizeWordStack(WS) <=Int 32
+
     rule #sizeWordStack(#take(N, _)) => N
     rule #sizeWordStack(WS) >=Int 0 => true [smt-lemma]
 

--- a/resources/rules.k.tmpl
+++ b/resources/rules.k.tmpl
@@ -247,7 +247,6 @@ rule ACCTCODE in SetItem( 1 )
        andBool #sizeWordStack(WS) >=Int (D /Int 8)
        andBool #sizeWordStack(WS) <=Int 32
     rule #sizeWordStack(#take(N, _)) => N
-    rule #sizeWordStack(#take(N, _), M) => N +Int M
 
     syntax WordStack ::= #asByteStackInWidth    ( Int, Int )                 [function]
                        | #asByteStackInWidthaux ( Int, Int, Int, WordStack ) [function]
@@ -478,12 +477,6 @@ rule ACCTCODE in SetItem( 1 )
 
 
 
-
-    rule #sizeWordStack ( _ , _ ) >=Int 0 => true [smt-lemma]
-    rule #sizeWordStack ( WS , N:Int )
-      => #sizeWordStack ( WS , 0 ) +Int N
-      requires N =/=K 0
-      [lemma]
 
 rule chop(#unsigned(W)) => #unsigned(W)
   requires #rangeSInt(256, W)

--- a/resources/rules.k.tmpl
+++ b/resources/rules.k.tmpl
@@ -1,3 +1,4 @@
+// -*- mode: k3; -*-
 // VERIFICATION.k
 
     rule #rangeUInt    (   1 ,      X ) => #range ( 0               <= X <= 1               ) [macro]

--- a/resources/rules.k.tmpl
+++ b/resources/rules.k.tmpl
@@ -247,6 +247,7 @@ rule ACCTCODE in SetItem( 1 )
        andBool #sizeWordStack(WS) >=Int (D /Int 8)
        andBool #sizeWordStack(WS) <=Int 32
     rule #sizeWordStack(#take(N, _)) => N
+    rule #sizeWordStack(WS) >=Int 0 => true [smt-lemma]
 
     syntax WordStack ::= #asByteStackInWidth    ( Int, Int )                 [function]
                        | #asByteStackInWidthaux ( Int, Int, Int, WordStack ) [function]


### PR DESCRIPTION
This PR bumps evm-semantics to include [this commit](https://github.com/dapphub/evm-semantics/commit/851b6df9e3ecd74f4a8c6dbb42a96c81b73c284a), which simplifies `sizeWordStack`, removes `sizeWordStackAux`, and obviates the need for our own rules in `rules.k.tmpl`.