### PR TITLE
Revert "util: add timestamp to build_hash"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -98,12 +98,10 @@ const getBuildId = () => {
 
   const klab_HEAD     = getKlabHEAD();
   const project_HEAD     = getProjectHEAD();
-  const timestamp = Date.now();
 
   const build_hash = sha3(JSON.stringify({
     project_HEAD, // e.g. current k-dss git HEAD
     klab_HEAD,    // e.g. klab master HEAD
-    timestamp,
   })).slice(0, 20);
 
   return build_hash;


### PR DESCRIPTION
This reverts commit ca50eb35c50343b3772596b50bed49abaf03aa6c.

`getBuildId` is called multiple times as part of klab-prove-all, and incorporating a timestamp meant that it returned a different result each time, messing up the reports in CI.