### PR TITLE
klab-prove-all: ensure report dir exists

### DIFF
--- a/libexec/klab-prove-all
+++ b/libexec/klab-prove-all
@@ -42,6 +42,7 @@ if [ -d ".git" ]; then
   if [ -n "$KLAB_REPORT_DIR" ]; then
     export KLAB_REPORT_NAME_DIR=$KLAB_REPORT_DIR/$PNAME
     export KLAB_REPORT_PROJECT_DIR=$KLAB_REPORT_DIR/$PNAME/$build_hash
+    mkdir -p $KLAB_REPORT_PROJECT_DIR
     if [ -n "$PNAME" ]; then
       klab setup-ci-project --no-overwrite --report-dir "${KLAB_REPORT_DIR}" --project-name "${PNAME}"
     fi;


### PR DESCRIPTION
`KLAB_REPORT_PROJECT_DIR` did not exist, and so the `cp` in [`report()`](https://github.com/dapphub/klab/blob/9f035f4ec58d7a7d862b9dbd91e9a1636dbde4e6/libexec/klab-prove-all#L64) was writing the `index.html` to `KLAB_REPORT_PROJECT_DIR` as a file, instead of as a
file inside of `KLAB_REPORT_PROJECT_DIR`.

This was resulting in messed up reports in CI. This commit ensures the report directory always exists.