### PR TITLE
klab-prove: make padRightToWidth symbolic

### DIFF
--- a/libexec/klab-prove
+++ b/libexec/klab-prove
@@ -104,7 +104,6 @@ concrete_rules=(
   EVM-TYPES.#asByteStack
   EVM-TYPES.#asByteStackAux.recursive
   EVM-TYPES.#padToWidth
-  EVM-TYPES.#padRightToWidth
   EVM.#memoryUsageUpdate.some
   SERIALIZATION.keccak
   SERIALIZATION.#newAddr


### PR DESCRIPTION
This fixes some broken specs that were passing before we bumped the evms.