### PR TITLE
meta: use direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+# vim: set ft=sh:
+
+if has lorri; then
+    eval "$(lorri direnv)"
+else
+    use nix
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -39,8 +39,8 @@ pkgs.stdenv.mkDerivation {
     z3
   ];
   shellHook = ''
-    export PATH=$PWD/node_modules/.bin/:$PWD/bin:$PATH
-    export KLAB_EVMS_PATH="''${KLAB_EVMS_PATH:-''${PWD}/evm-semantics}"
+    export PATH=${toString ./node_modules/.bin}:${toString ./bin}:$PATH
+    export KLAB_EVMS_PATH="''${KLAB_EVMS_PATH:-${toString ./evm-semantics}}"
     export NODE_OPTIONS="--max-old-space-size=4096"
   '';
 }


### PR DESCRIPTION
- Support `lorri` in `shell.nix`
- Add a `.envrc` and use `lorri` if available