### PR TITLE
build.js: unify proof hash calculation

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -218,7 +218,7 @@ const make_args = inputs => inputs && inputs.length == 0
     && ".TypedArgs"
     || inputs.map(make_abi_dsl).join(", ")
 
-const makeInterabiExhaustiveness = (alias, cname, contract) => {
+const makeInterabiExhaustiveness = (alias, cname, contract, hasher) => {
   const if_not_entries = contract.abi
     .filter(fabi => fabi.type == "function")
     .map(fabi => sha3(fabi.name + `(${fabi.inputs.map(i => i.type).join(",")})`).slice(0, 8))
@@ -245,7 +245,7 @@ const makeInterabiExhaustiveness = (alias, cname, contract) => {
     }
   })
 
-  const id = sha3(spec);
+  const id = hasher({name: cname, spec: spec});
 
   const status = getStatus(id);
 

--- a/libexec/klab-build-js
+++ b/libexec/klab-build-js
@@ -95,8 +95,7 @@ config.get_proof_hash = ({name, spec}) => {
     rules: rules_str,
     smt_prelude: prelude_str,
     spec : spec,
-    timeout: timeouts[name] || null,
-    smt_prelude: prelude_str,
+    timeout: timeouts[name] || null
   }
   if (memory[name]) proof.memory = memory[name];
   return sha3(JSON.stringify(proof))
@@ -109,7 +108,7 @@ Object.keys(config.implementations)
   .forEach(alias => {
     const cname = config.implementations[alias].name
     const name = alias + "__exhaustiveness";
-    const {id, module, status} = makeInterabiExhaustiveness(alias, cname, config.contracts[cname])
+    const {id, module, status} = makeInterabiExhaustiveness(alias, cname, config.contracts[cname], config.get_proof_hash)
 
     // TODO - write meta/data and name
 


### PR DESCRIPTION
Uses the same proof hash calculation algorithm for the exhaustiveness specs as the "normal" specs.

Should hopefully fix some cache invalidation issues in CI by forcing new runs for exhaustiveness specs when the klab commit changes.