### PR TITLE
Report formatting

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -32,6 +32,7 @@ const newCleanup = (act, text) => {
     .keys(act.storage || {})
     .map(subjectName => {
       // TODO - export this one level higher - all storages
+      let isCreate = act.creates[subjectName];
       let max_key_length = Object
         .keys(act.storage[subjectName])
         .map(key => key.length)
@@ -54,12 +55,18 @@ const newCleanup = (act, text) => {
             + key
             + " ".repeat(max_key_length - key.length)
             + " |-> "
-            + rewrites.join(" => ")
-          let comment_str = def && ("  // " + def.doc(key_) + "\n") || ""
+            + (isCreate ? rewrites[0] : rewrites.join(" => "))
+          let comment_str = def && def.doc(key_) && ("  // " + def.doc(key_) + "\n") || ""
           return comment_str + storage_str;
         })
         .join("\n")
-      return "storage" + (subjectName !== "ACCT_ID" ? " " + subjectName : "") + "\n" + storage + "\n";
+
+      // Return the storage block header + body
+      // - append the contract name to the header when referencing external contracts
+      // - preserve the creates header when present
+      let prefix = isCreate ? "creates storage" : "storage"
+      let header = prefix + (subjectName !== "ACCT_ID" ? " " + subjectName : "");
+      return header + "\n\n" + storage + "\n";
     })
     .join("\n\n")
 
@@ -67,7 +74,7 @@ const newCleanup = (act, text) => {
     .split(/\n/)
     .reduce(({isStorage, display}, line) => {
       const isStorageBlock = (/^storage$/).test(line);
-      const isOtherStorageBlock = (/^storage\s+\w/).test(line);
+      const isOtherStorageBlock = (/^(storage|creates storage)\s+\w/).test(line);
       const isBlock = (/^\w/).test(line);
       const isStorage_ = isStorageBlock || isOtherStorageBlock || (isStorage && !isBlock);
 
@@ -91,6 +98,7 @@ const newCleanup = (act, text) => {
     .replace(/\/\/(.*)\n/gm, (_1, _2, l) => `<span class="comment">//${_2}</span>\n`)
     .replace(/\s*\`[^\?\`]*\?([^\:\`]*)\:[^\`]*\`\s*/g, (_1, s) => s.trim() == "" ? " " : ` ${s.trim()} `)
     .replace(/\`([^\`]*)\`/g, (_, s) => `<span class="var">${s}</span>`)
+    .replace(/<</, "&lt;&lt;")
 
 
   const id = act.subject + "_" + act.sig;


### PR DESCRIPTION
Fixes for a few anomalies on the html report:

- Don't duplicate creates storage blocks
- Don't rewrite creates storage blocks
- Don't render empty storage block `doc:` comments
- Replace left bitshift with html entities