### PR TITLE
resources/k.json: assert ACCT_ID is never 0

### DIFF
--- a/resources/k.json
+++ b/resources/k.json
@@ -66,6 +66,7 @@
   },
   "requires": [
     "#rangeAddress(ACCT_ID)",
+    "andBool ACCT_ID =/=Int 0",
     "andBool #notPrecompileAddress(ACCT_ID)",
     "andBool #rangeAddress(CALLER_ID)",
     "andBool #rangeAddress(ORIGIN_ID)",


### PR DESCRIPTION
It's never possible for a contract to have address 0, so we shouldn't waste any time exploring this possibility in proofs.