### PR TITLE
shell.nix: add unzip to buildInputs

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -34,6 +34,7 @@ pkgs.stdenv.mkDerivation {
     python
     python3
     time
+    unzip
     wget
     zip
     z3


### PR DESCRIPTION
Used in klab-fetch.

We could also use [atool](https://www.nongnu.org/atool/), which replaces zip and
unzip.