### PR TITLE
lib/formatmemory.js: use = for var placeholders

### DIFF
--- a/lib/formatmemory.js
+++ b/lib/formatmemory.js
@@ -59,7 +59,10 @@ const formatMemory = mem => {
     str = "0".repeat(4 - str.length % 4) + str
     return clc.xterm(244)(str);
   }
-  let gv = i => i in variables && "$"+i+" - "+variables[i] || "";
+
+  // create a placeholder of the form `$i` for expressions which don't fit in the
+  // memory view, and display the full expression on the side
+  let gv = i => i in variables && "$"+i+" = "+variables[i] || "";
   lines.push(line + " ".repeat(LINELENGTH - clc.getStrippedLength(line)))
   lines = lines.map((line, i) => gt(i) + "  " + line + "    " + gv(i))
 


### PR DESCRIPTION
Use `=` instead of `-`, which looks like part of the expression.

Used when showing long variable placeholders in the memory view.