### PR TITLE
fix antimatch view - include variable diffs

### DIFF
--- a/lib/kast.js
+++ b/lib/kast.js
@@ -63,9 +63,12 @@ const joinMatches = (match1, match2) => {
   return newMatch
 }
 
-
 const antimatch = (pattern, term, path = []) => {
-  if (pattern.node == KVARIABLE) {
+  if (pattern.node == KVARIABLE && term.node == KVARIABLE && term.name != pattern.name && term.originalName[0] != "_" && pattern.originalName[0] != "_") {
+    return [
+      [path, format(pattern), format(term)]
+    ];
+  } else if (pattern.node == KVARIABLE) {
     return [];
   } else if (pattern.node == KAPPLY && term.node == KAPPLY && pattern.label == term.label && pattern.label == "_Map_") {
     // gather keys lhs


### PR DESCRIPTION
variables that were present in the spec and are not runtime variables are included in the antimatch view if they dont match. May include false positives.