### PR TITLE
shell.nix: bump nixpkgs to 20.03

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@ let
   pkgs = import (builtins.fetchGit rec {
     name = "nixpkgs-19.09-${rev}";
     url = https://github.com/nixos/nixpkgs;
-    ref = "nixos-19.09";
-    # git ls-remote https://github.com/nixos/nixpkgs-channels nixos-19.09
-    rev = "9f453eb97ffe261ff93136757cd08b522fac83b7";
+    ref = "nixos-20.03";
+    # git ls-remote https://github.com/nixos/nixpkgs-channels nixos-20.03
+    rev = "0bb35152be895abfd1fc743b42f1c4e56ae71906";
   }) {};
 in
 pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
This gives us z3 4.8.7, which includes a fix for [this issue](https://github.com/Z3Prover/z3/issues/2458) that has probably caused a few of our uniswap proofs to fail. 