### PR TITLE
rules.k.tmpl: fix typo in keccakIntList

### DIFF
--- a/resources/rules.k.tmpl
+++ b/resources/rules.k.tmpl
@@ -219,7 +219,7 @@ rule ACCTCODE in SetItem( 1 )
       requires ( notBool #isConcrete(WS) )
 
     rule 0 <=Int keccakIntList(N)     => true
-    rule keccaktIntList(N) <Int pow256 => true
+    rule keccakIntList(N) <Int pow256 => true
 
     rule #padToWidth(32, #asByteStack(V)) => #asByteStackInWidth(V, 32)
       requires 0 <=Int V andBool V <Int pow256


### PR DESCRIPTION
Showed up as one of the warnings of undefined var on RHS.