### PR TITLE
*: use ? for variables introduced in RHS

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -909,7 +909,7 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, lemma}) => {
     || "_ => _";
 
   // STATUSCODE
-  const statusCode = (pass && !oog) ? (act.internal ? "_" : "EVMC_SUCCESS") : "FAILURE:EndStatusCode"
+  const statusCode = (pass && !oog) ? (act.internal ? "_" : "EVMC_SUCCESS") : "?FAILURE:EndStatusCode"
 
   // IMPORTS
   const imports = (act.calls || [])

--- a/resources/k.json
+++ b/resources/k.json
@@ -29,8 +29,8 @@
         },
         "substate": {
           "selfDestruct": "VSelfDestruct",
-          "log": "_ => VLog",
-          "refund": "_ => VRefund"
+          "log": "_ => ?VLog",
+          "refund": "_ => ?VRefund"
         },
         "gasPrice": "_",
         "origin": "ORIGIN_ID",


### PR DESCRIPTION
Should fix some of the [warnings](https://cyberbrain.technology/k-uniswap/7af400397e21bc264209758a0a968c5f01ead31d8e9f4aebd430d561fac8d61a.err.log) at the bottom.

There are more cases that I found less straightforward, like when it complains
about `_ => _` - I haven't fixed those.

[Here](https://github.com/kframework/k/blob/master/pending-documentation.md#variables-occurring-only-in-the-rhs-of-a-rule) is the documentation of the new syntax.