### PR TITLE
libexec/klab-report: use config.host

### DIFF
--- a/libexec/klab-report
+++ b/libexec/klab-report
@@ -179,7 +179,7 @@ const getBadges = (cases, act) => {
 
       let zip = "";
       if(finished && hasZip) {
-        zip = tr(`<td colspan="4" class="zipselect">${h(['input', `class="autoselect" type="text" value="klab fetch http://${config.host}/${config.name}/${s.proofid+'.zip'}" onfocus="this.select()"`])("")}</td>`)
+        zip = tr(`<td colspan="4" class="zipselect">${h(['input', `class="autoselect" type="text" value="klab fetch https://${config.host}/${config.name}/${s.proofid+'.zip'}" onfocus="this.select()"`])("")}</td>`)
       } else if (rejected || aborted) {
         zip = tr(`<td colspan="4" class="zipselect">${h(['input', `class="autoselect" type="text" value="No log archive found"`])("")}</td>`)
       }

--- a/libexec/klab-report
+++ b/libexec/klab-report
@@ -179,7 +179,7 @@ const getBadges = (cases, act) => {
 
       let zip = "";
       if(finished && hasZip) {
-        zip = tr(`<td colspan="4" class="zipselect">${h(['input', `class="autoselect" type="text" value="klab fetch http://dapp.ci/${config.name}/${s.proofid+'.zip'}" onfocus="this.select()"`])("")}</td>`)
+        zip = tr(`<td colspan="4" class="zipselect">${h(['input', `class="autoselect" type="text" value="klab fetch http://${config.host}/${config.name}/${s.proofid+'.zip'}" onfocus="this.select()"`])("")}</td>`)
       } else if (rejected || aborted) {
         zip = tr(`<td colspan="4" class="zipselect">${h(['input', `class="autoselect" type="text" value="No log archive found"`])("")}</td>`)
       }


### PR DESCRIPTION
Rather than hardcoded dapp.ci.

Also switches to HTTPS.