### PR TITLE
lib/behaviour.js: show X for invalid opcodes

### DIFF
--- a/lib/behavior.js
+++ b/lib/behavior.js
@@ -89,12 +89,13 @@ const genBehaviour = (state, init = null) => {
         evm = kast.get(k, "ethereum.evm");
         if(evm) {
             node.revert = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_REVERT_NETWORK";
+            node.invalid = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_INVALID_INSTRUCTION_NETWORK";
             node.oog = kast.get(k, "ethereum.evm.statusCode").label == "EVMC_OUT_OF_GAS_NETWORK";
             node.gas = kast.get(k, "ethereum.evm.callState.gas");
         }
       }
       if(circular[node]) node.status = "circular";
-      if(node.revert) {
+      if(node.revert || node.invalid) {
         node.status = "❌";
       }
       if(node.head) node.head = (node.head || node.index) + (node.status ? " " + node.status : "");


### PR DESCRIPTION
Shows an x in the behaviour tree for branches terminating with an invalid instruction. This happens on e.g. divide by zero.