### PR TITLE
prove-all: support running in a worktree

### DIFF
--- a/libexec/klab-prove-all
+++ b/libexec/klab-prove-all
@@ -31,7 +31,7 @@ PNAME=$(jq -r '.name' < config.json)
 if [ "$PNAME" == "null" ]; then PNAME=""; fi
 export PNAME
 
-if [ -d ".git" ]; then
+if [ -d ".git" ] || [ -f ".git" ]; then
   build_hash=$(klab get-build-id)
   export build_hash
   if [ -n "$KLAB_REPORT_DIR" ]; then


### PR DESCRIPTION
Git supports multiple worktrees per repository (`git worktree add <PATH>`). When inside one of these worktrees .git is a file pointing to the directory containing the repository (gitdir: <PATH>) instead of a
directory and so prove-all did not setup the ci project as expected.