### PR TITLE
libexec/klab-prove-all: unaccept BADGAS specs

### DIFF
--- a/libexec/klab-prove-all
+++ b/libexec/klab-prove-all
@@ -122,6 +122,7 @@ do_proof () {
       cp "$GAS_DIR/${hash}.all.json" "$KLAB_REPORT_NAME_DIR"
     elif [ -n "$KLAB_REPORT_NAME_DIR" ]; then
       echo "${magenta}Proof ${bold}BADGAS${reset}: $hash [$name]"
+      rm -f "$KLAB_OUT/accept/$hash"
       savelogs "$hash"
     fi
     klab get-lemmas "$hash"


### PR DESCRIPTION
Remove them from the accept directory, so that the whole process is restarted.

This is not ideal (since the proof had already been accepted), but the
alternative risks giving false positives if one doesn't inspect the
build log.