### PR TITLE
add blake2 precompile

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -806,6 +806,16 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, lemma}) => {
       nonce:   "_"
     }
   }
+  const precompile9 = {
+    account: {
+      acctID:  9,
+      balance: 'BLAKE2_BAL',
+      code:    '.WordStack',
+      storage: '_:Map',
+      origStorage: "_",
+      nonce:   "_"
+    }
+  }
 
   const accounts = Object.keys(act.storage)
     .map(buildAccount)
@@ -817,6 +827,7 @@ const buildAct = config => ({act, oog, pass, name, hasGas, gas, lemma}) => {
     .concat(precompile6)
     .concat(precompile7)
     .concat(precompile8)
+    .concat(precompile9)
     .concat(["..."])
 
   // IF

--- a/resources/k.json
+++ b/resources/k.json
@@ -80,6 +80,7 @@
     "andBool #rangeUInt(256, ECADD_BAL)",
     "andBool #rangeUInt(256, ECMUL_BAL)",
     "andBool #rangeUInt(256, ECPAIRING_BAL)",
+    "andBool #rangeUInt(256, BLAKE2_BAL)",
     "andBool VCallDepth <=Int 1024",
     "andBool #rangeUInt(256, VCallValue)",
     "andBool #rangeUInt(256, VChainId)"


### PR DESCRIPTION
Makes the precompiles consistent with the lemmas in `rules.k.tmpl`, which assume that 9 precompiles exist.