### PR TITLE
libexec/klab-report: stop checking for empty files

### DIFF
--- a/libexec/klab-report
+++ b/libexec/klab-report
@@ -156,8 +156,8 @@ const getBadges = (cases, act) => {
       const gasPath = path.join(KLAB_OUT, "gas", s.proofid + ".all.json");
 
       const lemmaPath = path.join(KLAB_OUT, "log", s.proofid + "_lemma_stats.json");
-      const hasOut = testPath(outPath) && read(outPath).trim() !== "";
-      const hasErr = testPath(errPath) && read(errPath).trim() !== "";
+      const hasOut = testPath(outPath);
+      const hasErr = testPath(errPath);
       const hasTarball = testPath(tarballPath);
       const hasGas = testPath(gasPath);
 


### PR DESCRIPTION
The call to `read()` was reading the whole file in memory, which would
explode at runtime for very long logs.

This commit removes the check on empty files, which could result in
links being shown in the report page that are effectively useless.

The ideal solution would be to use something like Node's `Stream` class,
to perform the same check without loading everything in memory. Decided
not to implement this for now, as the feature being removed doesn't seem
important enough to warrant spending the necessary time dealing with Node.js in
order to re-implement it with Streams.

Let me know what you think.