### PR TITLE
Format fix

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -971,7 +971,7 @@ const buildActs = (config, act_proofs) => {
       pass: true,
       rough: false,
       hasGas: true,
-      gas: gas_json.map(g => kast.format(g, true, true))
+      gas: gas_json.map(g => kast.format(g, /*isRaw=*/ true, /*mixFix=*/ true, /*colorize=*/ false, /*forSpec=*/ true))
     };
 
     return {

--- a/lib/kast.js
+++ b/lib/kast.js
@@ -434,7 +434,6 @@ const format = (term, isRaw = false, mixFix = false, colorize = false, forSpec =
   } else {
     return `UNKNOWN<${ JSON.stringify(term) }>`
   }
-  // if(label == "keccak") console.log(str);
   return str;
 }
 

--- a/lib/kast.js
+++ b/lib/kast.js
@@ -301,7 +301,7 @@ const omitCells = (o, cellNames) => {
   return o;
 }
 
-const format = (term, isRaw = false, mixFix = false, colorize = false) => {
+const format = (term, isRaw = false, mixFix = false, colorize = false, forSpec = false) => {
   var str;
   if(term.node == KVARIABLE) {
     str = (/^(.*)_\d+\:\w+$/).test(term.originalName)
@@ -338,7 +338,7 @@ const format = (term, isRaw = false, mixFix = false, colorize = false) => {
       "4294967295": "maxUInt32",
       "1000000000000000000000000000": "#Ray"
     }
-    str = term.token in pt
+    str = (!forSpec && term.token in pt)
         ? (colorize && clc.bold(pt[term.token]) || pt[term.token])
         : term.token
   }
@@ -360,7 +360,7 @@ const format = (term, isRaw = false, mixFix = false, colorize = false) => {
       , "#WordPackUInt112UInt112UInt32(_,_,_)_RULES": "wp[112 122 32]"
     }
     var label = term.label in tokenMap ? tokenMap[term.label] : term.label;
-    const childs = term.args.map(child => format(child, isRaw, mixFix))
+    const childs = term.args.map(child => format(child, isRaw, mixFix, colorize, forSpec))
         .filter(s => !(s == ''));
     if (childs.length == 0) {
       return label;
@@ -408,7 +408,7 @@ const format = (term, isRaw = false, mixFix = false, colorize = false) => {
     }
     if(label == "_==K_" && childs[1] == "true") {
       str = childs[0]
-    } else if(label == "_==K_" && childs[1] == "false") {
+    } else if(label == "_==K_" && childs[1] == "false" && !forSpec) {
       str = "~ " + childs[0]
     } else if(label == "_[_:=_]_EVM-TYPES") {
       str = `${childs[0]}\n[ ${childs[1]} := ${childs[2]} ]`;


### PR DESCRIPTION
`kast.format` is used to format gas expressions for use in `pass` specifications; recent changes (see #413) introduced changes that make the output of `format` unparseable by `K`.

This PR introduces a variable that can be used to differentiate between pretty-printing and generating valid `K` syntax for use in specifications, and applies it conservatively to prevent issues (i.e. there may be other situations in which it should be used, I didn't try to be exhaustive here).