### PR TITLE
don't pretty-print wordpacks in gas expressions

### DIFF
--- a/lib/kast.js
+++ b/lib/kast.js
@@ -357,7 +357,7 @@ const format = (term, isRaw = false, mixFix = false, colorize = false, forSpec =
       , "#dyn_length(_,_)_RULES" : "#dyn_length"
       , "#dyn_size(_,_)_RULES"   : "#dyn_size"
       , "maxInt(_,_)_INT-COMMON" : "maxInt"
-      , "#WordPackUInt112UInt112UInt32(_,_,_)_RULES": "wp[112 122 32]"
+      , "#WordPackUInt112UInt112UInt32(_,_,_)_RULES": forSpec ? "#WordPackUInt112UInt112UInt32"  : "wp[112 112 32]"
     }
     var label = term.label in tokenMap ? tokenMap[term.label] : term.label;
     const childs = term.args.map(child => format(child, isRaw, mixFix, colorize, forSpec))


### PR DESCRIPTION
This should fix the failure [here](https://dapp.ci/k-uniswap/378f3c7c7eff002f643b/#UniswapV2Pair_sync())