### PR TITLE
Remove assert ACCT_ID is never 0

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -490,6 +490,11 @@ const parseAct = config => (act_str, silent = false) => {
           a.calls = tail
               .map(l => l.trim())
               .filter(l => l != "")
+          a.if = (a.if || [])
+              .concat(a.calls.map(l => l.split(".")[0])
+              .filter(l => l != a.subject)
+              .filter((l, i, a) => a.indexOf(l) === i)
+              .map(l => `(${l} =/=Int 0)`))
       } else if(/^gas/.test(head)) {
           a.gas = tail
               .map(l => l.trim())

--- a/resources/k.json
+++ b/resources/k.json
@@ -66,6 +66,7 @@
   },
   "requires": [
     "#rangeAddress(ACCT_ID)",
+    "andBool ACCT_ID =/=Int 0",
     "andBool #notPrecompileAddress(ACCT_ID)",
     "andBool #rangeAddress(CALLER_ID)",
     "andBool #rangeAddress(ORIGIN_ID)",

--- a/resources/k.json
+++ b/resources/k.json
@@ -66,7 +66,6 @@
   },
   "requires": [
     "#rangeAddress(ACCT_ID)",
-    "andBool ACCT_ID =/=Int 0",
     "andBool #notPrecompileAddress(ACCT_ID)",
     "andBool #rangeAddress(CALLER_ID)",
     "andBool #rangeAddress(ORIGIN_ID)",


### PR DESCRIPTION
This is conflicting when running proofs with other proofs as lemmas. Per @MrChico " the assumption that `ACCT_ID =/= 0` might not be provable for other contracts"